### PR TITLE
Handle jsdom parse errors

### DIFF
--- a/src/readability.js
+++ b/src/readability.js
@@ -86,6 +86,10 @@ function read(html, options, callback) {
   }
 
   function jsdomParse(error, meta, body) {
+    if (error) {
+      return callback(error);
+    }
+
     if (typeof body !== 'string') body = body.toString();
     jsdom.env({
       html: body,


### PR DESCRIPTION
Prevents uncatchable exception and crash at old line 89, new line 93: `if (typeof body !== 'string') body = body.toString();`

Should fix #2
