### PR TITLE
version bump & last resort fix for luin/node-readability#8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-readability",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "author": "Zihua Li",
   "description": "Turning any web page into a clean view.",
   "homepage": "https://github.com/luin/node-readability",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -192,6 +192,8 @@ var grabArticle = module.exports.grabArticle = function (document, preserveUnlik
    * We also have to copy the body node so it is something we can modify.
    **/
   if (topCandidate === null || topCandidate.tagName === "BODY") {
+    // With no top candidate, bail out if no body tag exists as last resort.
+    if (!document.body) return new Error("No body tag was found.");
     topCandidate = document.createElement("DIV");
     topCandidate.innerHTML = document.body.innerHTML;
     document.body.innerHTML = "";

--- a/test/readability.test.js
+++ b/test/readability.test.js
@@ -1,4 +1,7 @@
-var readability = require('../src/readability');
+var readability = require('../src/readability')
+  , helpers = require('../src/helpers')
+  , jsdom = require( 'jsdom' )
+  , noBody = '<html><head><title>hi</title></head>hi!</html>'; 
 require('should');
 
 describe('node-readability', function () {
@@ -20,7 +23,14 @@ describe('node-readability', function () {
     });
   });
   it('should handle the html that missing body tag', function (done) {
-    readability.read('<html><head><title>hi</title></head>hi!</html>', function (err, read) {
+    readability.read(noBody, function (err, read) {
+      err.message.should.equal('No body tag was found.');
+      done();
+    });
+  });
+  it('should let helpers.grabArticle handle html that\'s missing a body tag', function (done) {
+    jsdom.env(noBody, [], function (errors, window) {
+      var err = helpers.grabArticle(window.document);
       err.message.should.equal('No body tag was found.');
       done();
     });


### PR DESCRIPTION
I experienced some errors with the same type of origin as discussed and resolved in https://github.com/luin/node-readability/issues/8

```
/Users/account/Code/testapp/node_modules/node-readability/src/helpers.js:203
    topCandidate.innerHTML = document.body.innerHTML;
                                          ^
TypeError: Cannot read property 'innerHTML' of null
    at Object.module.exports.grabArticle (/Users/account/Code/testapp/node_modules/node-readability/src/helpers.js:203:43)
    at /Users/account/Code/read/index.js:5:14
    at /Users/account/Code/read/node_modules/jsdom/lib/jsdom.js:252:9
    at process._tickCallback (node.js:415:13)
```

`jsdom` apparently doesn't a allow you to create a new `BODY` tag so there seems no resort but to return an Error when no body tag exists. 

Added a test to check for this.

```
  $ /usr/local/share/npm/bin/mocha test/readability.test.js 

  node-readability
    ✓ should get document (2152ms)
    ✓ should get document with frames (3177ms)
    ✓ should handle the html that missing body tag 
    ✓ should let helpers.grabArticle handle html that's missing a body tag 

  4 passing (5s)
```
