### PR TITLE
update to jsdom 0.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {
     "fetch": "0.3.x",
-    "jsdom": "0.6.x"
+    "jsdom": "0.8.x"
   },
   "engines": [
     "node >=0.6.0"


### PR DESCRIPTION
I am using node-readability with Meteor.js (nice work, btw!), and I am experiencing some bad behavior because of a bug in jsdom 0.6.x (https://github.com/tmpvar/jsdom/pull/688). This is fixed in 0.8.7, so I updated packages.json and ran tests - no problems as far as I can see. So would it be possible to update jsdom to a newer version?
