### PR TITLE
fixed crash when href/src empty

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -478,13 +478,19 @@ function fixLinks (e) {
     var imgs = e.getElementsByTagName('img');
     for (var i = imgs.length - 1; i >= 0; --i) {
           var src = imgs[i].getAttribute('src');
-          imgs[i].setAttribute('src', fixLink(src));
+          if(src)
+            {
+              imgs[i].setAttribute('src', fixLink(src));
+            }
     }
 
     var as = e.getElementsByTagName('a');
     for (var i = as.length - 1; i >= 0; --i) {
         var href = as[i].getAttribute('href');
-        as[i].setAttribute('href', fixLink(href));
+        if(href)
+          {
+            as[i].setAttribute('href', fixLink(href));
+          }
     }
 
 }


### PR DESCRIPTION
Some a link and img have no 'href' or 'src',that causes null. Obviously,url.resolve no null parameter.
