### PR TITLE
Working in browserify (ish)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     }
   ],
   "dependencies": {
-    "jsdom": "0.11.1",
+    "jsdom": "1.0.1",
     "request": "~2.40.0",
     "encoding": "~0.1.7"
   },

--- a/src/readability.js
+++ b/src/readability.js
@@ -158,6 +158,14 @@ function read(html, options, callback) {
   options.encoding = null;
 
   if (html.indexOf('<') === -1) {
+
+    // try to enable CORS on the browser
+    if (window) {
+      if (options.withEncoding === undefined) {
+        options.withEncoding = false;
+      }
+    }
+
     request(html, options, function(err, res, buffer) {
       if (err) {
         return callback(err);
@@ -190,6 +198,8 @@ function read(html, options, callback) {
     if (!body) return callback(new Error('Empty story body returned from URL'));
     jsdom.env({
       html: body,
+      // jank around jsdom browserify bug
+      url: (meta ? meta.request.uri.href : '/'),
       done: function(errors, window) {
         if (meta) {
           window.document.originalURL = meta.request.uri.href;

--- a/src/readability.js
+++ b/src/readability.js
@@ -160,8 +160,8 @@ function read(html, options, callback) {
   if (html.indexOf('<') === -1) {
 
     // try to enable CORS on the browser
-    if (window) {
-      if (options.withEncoding === undefined) {
+    if (typeof window !== 'undefined') {
+      if (typeof options.withEncoding === 'undefined') {
         options.withEncoding = false;
       }
     }


### PR DESCRIPTION
The user still needs to `ignore` iconv in browserify, though I recently submitted a PR to `encoding` that fixes that. 
