### PR TITLE
Extraction improvements (blogspot fix)

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -4,7 +4,7 @@ var url = require("url");
 var regexps = {
   unlikelyCandidatesRe: /combx|modal|lightbox|comment|disqus|foot|header|menu|meta|nav|rss|shoutbox|sidebar|sponsor|social|teaserlist|time|tweet|twitter/i,
   okMaybeItsACandidateRe: /and|article|body|column|main/i,
-  positiveRe: /article|body|content|entry|hentry|page|pagination|post|text/i,
+  positiveRe: /article|body|content|entry|hentry|page|pagination|post|section|chapter|text/i,
   negativeRe: /combx|comment|contact|foot|footer|footnote|link|media|meta|promo|related|scroll|shoutbox|sponsor|utility|tags|widget/i,
   divToPElementsRe: /<(a|blockquote|dl|div|img|ol|p|pre|table|ul)/i,
   replaceBrsRe: /(<br[^>]*>[ \n\r\t]*){2,}/gi,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -4,7 +4,7 @@ var url = require("url");
 var regexps = {
   unlikelyCandidatesRe: /combx|modal|lightbox|comment|disqus|foot|header|menu|meta|nav|rss|shoutbox|sidebar|sponsor|social|teaserlist|time|tweet|twitter/i,
   okMaybeItsACandidateRe: /and|article|body|column|main/i,
-  positiveRe: /article|body|content|entry|hentry|page|pagination|post|section|chapter|text/i,
+  positiveRe: /article|body|content|entry|hentry|page|pagination|post|section|chapter|description|main|blog|text/i,
   negativeRe: /combx|comment|contact|foot|footer|footnote|link|media|meta|promo|related|scroll|shoutbox|sponsor|utility|tags|widget/i,
   divToPElementsRe: /<(a|blockquote|dl|div|img|ol|p|pre|table|ul)/i,
   replaceBrsRe: /(<br[^>]*>[ \n\r\t]*){2,}/gi,

--- a/test/result.js
+++ b/test/result.js
@@ -1,4 +1,5 @@
 require('./mock-helpers.js');
+var fs = require('fs');
 var read = require('../src/readability');
 
 describe('result', function() {
@@ -15,7 +16,7 @@ describe('result', function() {
   });
 
   it('should get document with frames', function(done) {
-    read('http://www.whitehouse.gov/', function(err, read) {
+    read(fs.readFileSync(__dirname + '/white-house.html').toString(), function(err, read) {
       var dom = read.document;
       read.title.should.equal('The White House');
       read.close.should.be.a.Function

--- a/test/white-house.html
+++ b/test/white-house.html
@@ -1,0 +1,653 @@
+<html lang="en" dir="ltr" prefix="content: http://purl.org/rss/1.0/modules/content/ dc: http://purl.org/dc/terms/ foaf: http://xmlns.com/foaf/0.1/ og: http://ogp.me/ns# rdfs: http://www.w3.org/2000/01/rdf-schema# sioc: http://rdfs.org/sioc/ns# sioct: http://rdfs.org/sioc/types# skos: http://www.w3.org/2004/02/skos/core# xsd: http://www.w3.org/2001/XMLSchema# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article# book: http://ogp.me/ns/book# profile: http://ogp.me/ns/profile# video: http://ogp.me/ns/video#" class="js"><!--<![endif]--><head>
+  <meta charset="utf-8">
+<link rel="apple-touch-icon" sizes="180x180" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/iOS_180x180.png">
+<link rel="apple-touch-icon-precomposed" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/apple-touch-icon-60x60-precomposed.png">
+<link rel="apple-touch-icon" sizes="167x167" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/iOS_167x167.png">
+<link rel="apple-touch-icon" sizes="120x120" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/iOS_120x120.png">
+<link rel="apple-touch-icon" sizes="76x76" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/iOS_76x76.png">
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/apple-touch-icon-57x57-precomposed.png">
+<link rel="apple-touch-icon" sizes="152x152" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/iOS_152x152.png">
+<link rel="apple-touch-icon-precomposed" sizes="60x60" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/apple-touch-icon-60x60-precomposed.png">
+<link rel="apple-touch-icon-precomposed" sizes="120x120" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/apple-touch-icon-120x120-precomposed.png">
+<link rel="apple-touch-icon-precomposed" sizes="144x144" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/apple-touch-icon-144x144-precomposed.png">
+<style type="text/css"></style><link rel="apple-touch-icon-precomposed" sizes="114x114" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/apple-touch-icon-114x114-precomposed.png">
+<link rel="apple-touch-icon-precomposed" sizes="76x76" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/apple-touch-icon-76x76-precomposed.png">
+<link rel="apple-touch-icon-precomposed" sizes="72x72" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/apple-touch-icon-72x72-precomposed.png">
+<link rel="apple-touch-icon" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/iOS_76x76.png">
+<link rel="icon" type="image/png" sizes="16x16" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/favicon-16x16.png">
+<meta name="msapplication-square70x70logo" content="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/mstile-70x70.png">
+<meta name="msapplication-TileImage" content="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/mstile-70x70.png">
+<meta name="msapplication-square150x150logo" content="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/mstile-150x150.png">
+<meta name="msapplication-wide310x150logo" content="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/mstile-310x150.png">
+<link rel="shortcut icon" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/favicon.ico" type="image/vnd.microsoft.icon">
+<meta name="msapplication-square310x310logo" content="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/mstile-310x310.png">
+<meta name="msapplication-TileColor" content="#003C80">
+<meta name="application-name" content="Whitehouse">
+<link rel="icon" type="image/png" sizes="96x96" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/favicon-96x96.png">
+<link rel="icon" type="image/png" sizes="32x32" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="128x128" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/favicon-128.png">
+<link rel="icon" type="image/png" sizes="196x196" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/favicon-196x196.png">
+<meta name="msapplication-config" content="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/browserconfig.xml">
+<link rel="apple-touch-icon-precomposed" sizes="152x152" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/images/fortyfour/favicons/apple-touch-icon-152x152-precomposed.png">
+<link rel="shortcut icon" href="https://www.whitehouse.gov/profiles/forall/themes/custom/fortyfour/favicon.ico" type="image/vnd.microsoft.icon">
+<meta name="description" content="See the President's daily schedule, explore behind-the-scenes photos from inside the White House, and find out all the ways you can engage with the most interactive administration in our country's history.">
+<meta name="abstract" content="See the President's daily schedule, explore behind-the-scenes photos from inside the White House, and find out all the ways you can engage with the most interactive administration in our country's history.">
+<meta name="keywords" content="President,Barack Obama,White House,United States of America,44th President,White House history,President Obama,Barck,Barek,Barak,Barrack,Barrak,Obma,Barack">
+<meta name="generator" content="Drupal 7 (http://drupal.org)">
+<link rel="image_src" href="https://www.whitehouse.gov/sites/whitehouse.gov/files/images/fb_share_postcard.jpg">
+<link rel="canonical" href="https://www.whitehouse.gov/homepage">
+<link rel="shortlink" href="https://www.whitehouse.gov/homepage">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="whitehouse.gov">
+<meta property="og:title" content="The White House">
+<meta property="og:url" content="https://www.whitehouse.gov/homepage">
+<meta property="og:description" content="See the President's daily schedule, explore behind-the-scenes photos from inside the White House, and find out all the ways you can engage with the most interactive administration in our country's history.">
+<meta property="og:updated_time" content="2016-04-25T11:24:47-04:00">
+<meta property="og:image" content="https://www.whitehouse.gov/sites/whitehouse.gov/files/images/fb_share_postcard.jpg">
+<meta property="og:image:secure_url" content="https://www.whitehouse.gov/sites/whitehouse.gov/files/images/twitter_cards_default.jpg">
+<meta property="og:image:type" content="image/jpeg">
+<meta property="og:image:width" content="240">
+<meta property="og:image:height" content="240">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@WhiteHouse">
+<meta name="twitter:creator" content="@WhiteHouse">
+<meta name="twitter:url" content="https://www.whitehouse.gov/homepage">
+<meta name="twitter:title" content="The White House">
+<meta name="twitter:image:src" content="https://www.whitehouse.gov/sites/whitehouse.gov/files/images/twitter_cards_homepage.jpg">
+<meta name="twitter:image:width" content="240">
+<meta name="twitter:image:height" content="240">
+<meta property="article:published_time" content="2015-03-12T17:57:02-04:00">
+<meta property="article:modified_time" content="2016-04-25T11:24:47-04:00">
+  <title>The White House | whitehouse.gov</title>
+
+      <meta name="MobileOptimized" content="width">
+    <meta name="HandheldFriendly" content="true">
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="cleartype" content="on">
+
+  <link type="text/css" rel="stylesheet" href="https://www.whitehouse.gov/sites/whitehouse.gov/files/css/css_lQaZfjVpwP_oGNqdtWCSpJT1EMqXdMiU84ekLLxQnc4.css" media="all">
+<link type="text/css" rel="stylesheet" href="https://www.whitehouse.gov/sites/whitehouse.gov/files/css/css_yU1ecLb-JQK8Zu-UAxooO-nvU4puNy9Vo8PpzTa6cX4.css" media="all">
+<link type="text/css" rel="stylesheet" href="https://www.whitehouse.gov/sites/whitehouse.gov/files/css/css_2oCJ0RskfnmEh9znTNY-IJifw6J4BCzT2d88oZuCjDo.css" media="all">
+<link type="text/css" rel="stylesheet" href="https://www.whitehouse.gov/sites/whitehouse.gov/files/css/css_47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU.css" media="print">
+<link type="text/css" rel="stylesheet" href="https://www.whitehouse.gov/sites/whitehouse.gov/files/css/css_lhZ2r95cVv6XPZeCq2neqJ2WkJfOx4FGwB5NFslhk94.css" media="all">
+<link type="text/css" rel="stylesheet" href="https://cloud.typography.com/6570712/721006/css/fonts.css" media="all">
+<link type="text/css" rel="stylesheet" href="https://www.whitehouse.gov/sites/whitehouse.gov/files/css/css_n-PjoZ-gDcNukhc4jFBjlvpGzuEkmOSckysxO7f6tuo.css" media="all">
+<link type="text/css" rel="stylesheet" href="https://www.whitehouse.gov/sites/whitehouse.gov/files/css/css_bS-2Cq02LdaKdec12vU20dMGQSdgihJADtPC-kQVVmE.css" media="all">
+
+<!--[if lte IE 9]>
+<link type="text/css" rel="stylesheet" href="https://www.whitehouse.gov/profiles/forall/modules/custom/gov_whitehouse_www/modules/whitehouse_nav/css/whitehouse_nav_search_ie9.css?" media="all" />
+<![endif]-->
+  <!--[if lte IE 9]>
+    <link href="/profiles/forall/themes/custom/fortyfour/css/ie9.css" rel="stylesheet" type="text/css">
+  <![endif]-->
+  <script id="facebook-jssdk" src="//connect.facebook.net/en_US/sdk.js"></script><script async="" src="//www.google-analytics.com/analytics.js"></script><script src="https://www.whitehouse.gov/sites/whitehouse.gov/files/js/js_MpKfe1sTh5JIVGCZ17DsAuT1rqAC38MLLlkjqjQ1X_k.js"></script>
+<script src="https://www.whitehouse.gov/sites/whitehouse.gov/files/js/js_dpcaZHeWwtmqOEhy_RAIdKsPWHEDVNfKu0v8oY9XuOI.js"></script>
+<script src="https://www.whitehouse.gov/sites/whitehouse.gov/files/js/js_uPNzaRP-bkimN_p8zvZONy7fi8Oh54S1WQzdPUW-yro.js"></script>
+<script src="https://www.whitehouse.gov/sites/whitehouse.gov/files/js/js_7A5xyLkXyLAj7O051G-zmQW0DzTaab-GPGPcoPFTC3w.js"></script>
+<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","//www.google-analytics.com/analytics.js","ga");ga("create", "UA-12099831-1", {"cookieDomain":"auto"});ga("set", "anonymizeIp", true);ga("send", "pageview");</script>
+<script src="https://www.whitehouse.gov/sites/whitehouse.gov/files/js/js_ZLR9AniROdeoCHWP-EH_xh-8M8GedFTjELHBIFv_kys.js"></script>
+<script src="https://www.whitehouse.gov/sites/whitehouse.gov/files/js/js_BnLp98TAFdrK4aTBmEXyC9rHYtfrp4gWf3_kvziFVJc.js"></script>
+<script src="https://www.whitehouse.gov/sites/whitehouse.gov/files/js/js_S4ZZGC9DHcaMDgTpvRN7MBcmXkzFjVLWzboXJJewXOk.js"></script>
+<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"fortyfour","theme_token":"9vzB_bDO_QTUVIaIk8-jo6bQ3MMLPD3MNXbyMlYZLWA","jquery_version":"1.10","js":{"sites\/whitehouse.gov\/modules\/contrib\/jquery_update\/replace\/jquery\/1.10\/jquery.min.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"sites\/whitehouse.gov\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.core.min.js":1,"sites\/whitehouse.gov\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.widget.min.js":1,"sites\/whitehouse.gov\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.mouse.min.js":1,"sites\/whitehouse.gov\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.slider.min.js":1,"sites\/whitehouse.gov\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.tabs.min.js":1,"sites\/whitehouse.gov\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.accordion.min.js":1,"sites\/whitehouse.gov\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.button.min.js":1,"sites\/whitehouse.gov\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.draggable.min.js":1,"sites\/whitehouse.gov\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.position.min.js":1,"sites\/whitehouse.gov\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.resizable.min.js":1,"sites\/whitehouse.gov\/modules\/contrib\/jquery_update\/replace\/ui\/ui\/minified\/jquery.ui.dialog.min.js":1,"misc\/ajax.js":1,"sites\/whitehouse.gov\/modules\/contrib\/jquery_update\/js\/jquery_update.js":1,"profiles\/forall\/modules\/custom\/keyboard_navigation\/js\/keyboard_navigation.js":1,"sites\/whitehouse.gov\/modules\/contrib\/media_preview_slider\/js\/slider.js":1,"sites\/whitehouse.gov\/modules\/contrib\/panopoly_magic\/panopoly-magic.js":1,"sites\/whitehouse.gov\/modules\/contrib\/panopoly_theme\/js\/panopoly-accordion.js":1,"sites\/whitehouse.gov\/modules\/contrib\/linkit\/js\/linkit.js":1,"sites\/whitehouse.gov\/libraries\/superfish\/src\/js\/superfish.js":1,"profiles\/forall\/modules\/custom\/sixteenhundrednav\/sixteenhundrednav.js":1,"sites\/whitehouse.gov\/libraries\/colorbox\/jquery.colorbox-min.js":1,"sites\/whitehouse.gov\/modules\/contrib\/colorbox\/js\/colorbox.js":1,"profiles\/forall\/modules\/custom\/forall_checklist_fieldable_panels_pane\/js\/forall_checklist_fieldable_panels_pane.js":1,"profiles\/forall\/modules\/custom\/shareables\/shareables.js":1,"sites\/whitehouse.gov\/modules\/custom\/whr_blog_listings\/whr_blog_listings.js":1,"sites\/whitehouse.gov\/modules\/custom\/whr_briefing_room_listings\/whr_briefing_room_listings.js":1,"misc\/progress.js":1,"sites\/whitehouse.gov\/modules\/contrib\/linkit\/editors\/ckeditor\/linkitDialog.js":1,"sites\/whitehouse.gov\/modules\/contrib\/google_analytics\/googleanalytics.js":1,"0":1,"sites\/whitehouse.gov\/modules\/contrib\/social_share\/js\/social_share_facebook_sdk.js":1,"profiles\/forall\/modules\/custom\/forall_webforms\/forall_webforms.js":1,"profiles\/forall\/themes\/custom\/fortyfour\/js\/html5shiv.js":1,"profiles\/forall\/themes\/custom\/fortyfour\/js\/theme.js":1,"profiles\/forall\/modules\/custom\/forall_heroes\/js\/forall_heroes.js":1,"sites\/whitehouse.gov\/modules\/contrib\/picture\/picturefill\/matchmedia.js":1,"sites\/whitehouse.gov\/modules\/contrib\/picture\/picturefill\/picturefill.js":1,"sites\/whitehouse.gov\/modules\/contrib\/picture\/picture.js":1,"\/\/platform.twitter.com\/widgets.js":1,"sites\/whitehouse.gov\/modules\/contrib\/navbar\/js\/debounce.js":1,"sites\/whitehouse.gov\/modules\/contrib\/navbar\/js\/displace.js":1,"sites\/whitehouse.gov\/modules\/contrib\/navbar\/js\/navbar-tableheader.js":1,"1":1},"css":{"modules\/system\/system.base.css":1,"modules\/system\/system.menus.css":1,"modules\/system\/system.messages.css":1,"modules\/system\/system.theme.css":1,"misc\/ui\/jquery.ui.core.css":1,"misc\/ui\/jquery.ui.theme.css":1,"misc\/ui\/jquery.ui.slider.css":1,"misc\/ui\/jquery.ui.tabs.css":1,"misc\/ui\/jquery.ui.accordion.css":1,"misc\/ui\/jquery.ui.button.css":1,"misc\/ui\/jquery.ui.resizable.css":1,"misc\/ui\/jquery.ui.dialog.css":1,"modules\/comment\/comment.css":1,"sites\/whitehouse.gov\/modules\/contrib\/date\/date_api\/date.css":1,"sites\/whitehouse.gov\/modules\/contrib\/date\/date_popup\/themes\/datepicker.1.7.css":1,"modules\/field\/theme\/field.css":1,"profiles\/forall\/modules\/custom\/forall_river_of_content\/stylesheets\/forall_river_of_content.css":1,"profiles\/forall\/modules\/custom\/forall_secondary_nav\/stylesheets\/secondary_nav.css":1,"sites\/whitehouse.gov\/modules\/contrib\/media_preview_slider\/css\/slider-styles.css":1,"modules\/node\/node.css":1,"sites\/whitehouse.gov\/modules\/contrib\/panopoly_magic\/css\/panopoly-magic.css":1,"sites\/whitehouse.gov\/modules\/contrib\/panopoly_magic\/css\/panopoly-modal.css":1,"sites\/whitehouse.gov\/modules\/contrib\/panopoly_theme\/css\/panopoly-featured.css":1,"sites\/whitehouse.gov\/modules\/contrib\/panopoly_theme\/css\/panopoly-accordian.css":1,"sites\/whitehouse.gov\/modules\/contrib\/picture\/picture_wysiwyg.css":1,"modules\/search\/search.css":1,"profiles\/forall\/modules\/custom\/shareables\/stylesheets\/shareables.css":1,"profiles\/forall\/modules\/custom\/shareables\/shareable_colorbar_divider\/stylesheets\/shareable-colorbar-divider.css":1,"profiles\/forall\/modules\/custom\/shareables\/shareable_custom_text\/stylesheets\/shareable_custom_text.css":1,"profiles\/forall\/modules\/custom\/shareables\/shareable_divider\/stylesheets\/shareable-divider.css":1,"profiles\/forall\/modules\/custom\/shareables\/shareable_full_width\/stylesheets\/shareable_full_width.css":1,"profiles\/forall\/modules\/custom\/shareables\/shareable_survey_poll\/stylesheets\/shareable_survey_poll.css":1,"profiles\/forall\/modules\/custom\/shareables\/shareable_tweet\/stylesheets\/shareable_tweet.css":1,"profiles\/forall\/modules\/custom\/shareables\/shareable_video\/stylesheets\/shareable_video.css":1,"sites\/whitehouse.gov\/modules\/custom\/shortcodeapiiframe\/css\/shortcodeapiiframe.css":1,"sites\/whitehouse.gov\/modules\/custom\/shortcodeapislideshare\/css\/shortcodeapislideshare.css":1,"sites\/whitehouse.gov\/modules\/custom\/shortcodeapisocrata\/css\/shortcodeapisocrata.css":1,"sites\/whitehouse.gov\/modules\/custom\/shortcodeapitweet\/css\/shortcodeapitweet.css":1,"profiles\/forall\/modules\/custom\/shortcodeapiyoutube\/stylesheets\/shortcodeapiyoutube.css":1,"profiles\/forall\/modules\/custom\/sixteenhundredpanels\/stylesheets\/sixteen_hundred_panels.css":1,"modules\/user\/user.css":1,"profiles\/forall\/modules\/custom\/gov_whitehouse_www\/modules\/whitehouse_sotu2015\/stylesheets\/whitehouse_sotu2015.css":1,"sites\/whitehouse.gov\/modules\/contrib\/youtube\/css\/youtube.css":1,"profiles\/forall\/modules\/custom\/youtube_livestream_listings\/stylesheets\/youtubelivestreamlistings.css":1,"profiles\/forall\/modules\/custom\/youtube_livestream_multi\/stylesheets\/youtube_livestream_multi.css":1,"sites\/whitehouse.gov\/modules\/contrib\/views\/css\/views.css":1,"profiles\/forall\/modules\/custom\/sixteenhundrednav\/stylesheets\/screen.css":1,"profiles\/forall\/modules\/custom\/sixteenhundrednav\/stylesheets\/ie.css":1,"profiles\/forall\/modules\/custom\/sixteenhundrednav\/stylesheets\/print.css":1,"sites\/whitehouse.gov\/modules\/contrib\/ckeditor\/css\/ckeditor.css":1,"https:\/\/cloud.typography.com\/6570712\/721006\/css\/fonts.css":1,"sites\/whitehouse.gov\/modules\/contrib\/ctools\/css\/ctools.css":1,"sites\/whitehouse.gov\/modules\/contrib\/panels\/css\/panels.css":1,"profiles\/forall\/modules\/custom\/gov_whitehouse_www\/modules\/whitehouse_nav\/css\/whitehouse_nav_search.css":1,"sites\/whitehouse.gov\/libraries\/fontawesome\/css\/font-awesome.css":1,"profiles\/forall\/modules\/custom\/sixteenhundredfooter\/stylesheets\/sixteenhundredfooter.css":1,"profiles\/forall\/modules\/custom\/sixteenhundredfooter\/system.menus.css":1,"profiles\/forall\/modules\/custom\/sixteenhundredfooter\/system.messages.css":1,"profiles\/forall\/modules\/custom\/sixteenhundredfooter\/system.theme.css":1,"profiles\/forall\/themes\/custom\/fortyfour\/system.menus.css":1,"profiles\/forall\/themes\/custom\/fortyfour\/system.messages.css":1,"profiles\/forall\/themes\/custom\/fortyfour\/system.theme.css":1,"profiles\/forall\/themes\/custom\/fortyfour\/css\/styles.css":1,"profiles\/forall\/modules\/custom\/gov_whitehouse_www\/modules\/whitehouse_nav\/css\/whitehouse_nav_search_ie9.css":1}},"colorbox":{"opacity":"0.85","current":"{current} of {total}","previous":"\u00ab Prev","next":"Next \u00bb","close":"Close","maxWidth":"98%","maxHeight":"98%","fixed":true,"mobiledetect":true,"mobiledevicewidth":"480px"},"CToolsModal":{"modalSize":{"type":"scale","width":".9","height":".9","addWidth":0,"addHeight":0,"contentRight":25,"contentBottom":75},"modalOptions":{"opacity":".55","background-color":"#FFF"},"animationSpeed":"fast","modalTheme":"CToolsModalDialog","throbberTheme":"CToolsModalThrobber"},"linkit":{"autocompletePath":"https:\/\/www.whitehouse.gov\/linkit\/autocomplete\/___profile___?s=","dashboardPath":"\/linkit\/dashboard\/","currentInstance":{}},"urlIsAjaxTrusted":{"\/\/search.whitehouse.gov\/search":true},"currentPath":"node\/5596","currentPathIsAdmin":false,"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc(x|m)?|dot(x|m)?|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt(x|m)?|pot(x|m)?|pps(x|m)?|ppam|sld(x|m)?|thmx|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls(x|m|b)?|xlt(x|m)|xlam|xml|z|zip"},"socialShare":{"appID":"100929903392"},"tableHeaderOffset":"Drupal.navbar.height","clientsideValidation":{"general":{"months":{"January":1,"Jan":1,"February":2,"Feb":2,"March":3,"Mar":3,"April":4,"Apr":4,"May":5,"June":6,"Jun":6,"July":7,"Jul":7,"August":8,"Aug":8,"September":9,"Sep":9,"October":10,"Oct":10,"November":11,"Nov":11,"December":12,"Dec":12}}}});</script>
+<!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. --><script src="/sites/whitehouse.gov/modules/contrib/usfedgov_google_analytics/js/Universal-Federated-Analytics-Min.js?agency=Executive%20Office%20of%20the%20President&amp;subagency=The%20White%20House" type="text/javascript" id="_fed_an_ua_tag"></script>      <!--[if lt IE 9]>
+    <script src="/sites/whitehouse.gov/themes/contrib/zen/js/html5-respond.js"></script>
+    <![endif]-->
+  <style type="text/css">.fb_hidden{position:absolute;top:-10000px;z-index:10001}.fb_reposition{overflow:hidden;position:relative}.fb_invisible{display:none}.fb_reset{background:none;border:0;border-spacing:0;color:#000;cursor:auto;direction:ltr;font-family:"lucida grande", tahoma, verdana, arial, sans-serif;font-size:11px;font-style:normal;font-variant:normal;font-weight:normal;letter-spacing:normal;line-height:1;margin:0;overflow:visible;padding:0;text-align:left;text-decoration:none;text-indent:0;text-shadow:none;text-transform:none;visibility:visible;white-space:normal;word-spacing:normal}.fb_reset>div{overflow:hidden}.fb_link img{border:none}@keyframes fb_transform{from{opacity:0;transform:scale(.95)}to{opacity:1;transform:scale(1)}}.fb_animate{animation:fb_transform .3s forwards}
+.fb_dialog{background:rgba(82, 82, 82, .7);position:absolute;top:-10000px;z-index:10001}.fb_reset .fb_dialog_legacy{overflow:visible}.fb_dialog_advanced{padding:10px;-moz-border-radius:8px;-webkit-border-radius:8px;border-radius:8px}.fb_dialog_content{background:#fff;color:#333}.fb_dialog_close_icon{background:url(https://fbstatic-a.akamaihd.net/rsrc.php/v2/yq/r/IE9JII6Z1Ys.png) no-repeat scroll 0 0 transparent;_background-image:url(https://fbstatic-a.akamaihd.net/rsrc.php/v2/yL/r/s816eWC-2sl.gif);cursor:pointer;display:block;height:15px;position:absolute;right:18px;top:17px;width:15px}.fb_dialog_mobile .fb_dialog_close_icon{top:5px;left:5px;right:auto}.fb_dialog_padding{background-color:transparent;position:absolute;width:1px;z-index:-1}.fb_dialog_close_icon:hover{background:url(https://fbstatic-a.akamaihd.net/rsrc.php/v2/yq/r/IE9JII6Z1Ys.png) no-repeat scroll 0 -15px transparent;_background-image:url(https://fbstatic-a.akamaihd.net/rsrc.php/v2/yL/r/s816eWC-2sl.gif)}.fb_dialog_close_icon:active{background:url(https://fbstatic-a.akamaihd.net/rsrc.php/v2/yq/r/IE9JII6Z1Ys.png) no-repeat scroll 0 -30px transparent;_background-image:url(https://fbstatic-a.akamaihd.net/rsrc.php/v2/yL/r/s816eWC-2sl.gif)}.fb_dialog_loader{background-color:#f6f7f8;border:1px solid #606060;font-size:24px;padding:20px}.fb_dialog_top_left,.fb_dialog_top_right,.fb_dialog_bottom_left,.fb_dialog_bottom_right{height:10px;width:10px;overflow:hidden;position:absolute}.fb_dialog_top_left{background:url(https://fbstatic-a.akamaihd.net/rsrc.php/v2/ye/r/8YeTNIlTZjm.png) no-repeat 0 0;left:-10px;top:-10px}.fb_dialog_top_right{background:url(https://fbstatic-a.akamaihd.net/rsrc.php/v2/ye/r/8YeTNIlTZjm.png) no-repeat 0 -10px;right:-10px;top:-10px}.fb_dialog_bottom_left{background:url(https://fbstatic-a.akamaihd.net/rsrc.php/v2/ye/r/8YeTNIlTZjm.png) no-repeat 0 -20px;bottom:-10px;left:-10px}.fb_dialog_bottom_right{background:url(https://fbstatic-a.akamaihd.net/rsrc.php/v2/ye/r/8YeTNIlTZjm.png) no-repeat 0 -30px;right:-10px;bottom:-10px}.fb_dialog_vert_left,.fb_dialog_vert_right,.fb_dialog_horiz_top,.fb_dialog_horiz_bottom{position:absolute;background:#525252;filter:alpha(opacity=70);opacity:.7}.fb_dialog_vert_left,.fb_dialog_vert_right{width:10px;height:100%}.fb_dialog_vert_left{margin-left:-10px}.fb_dialog_vert_right{right:0;margin-right:-10px}.fb_dialog_horiz_top,.fb_dialog_horiz_bottom{width:100%;height:10px}.fb_dialog_horiz_top{margin-top:-10px}.fb_dialog_horiz_bottom{bottom:0;margin-bottom:-10px}.fb_dialog_iframe{line-height:0}.fb_dialog_content .dialog_title{background:#6d84b4;border:1px solid #3a5795;color:#fff;font-size:14px;font-weight:bold;margin:0}.fb_dialog_content .dialog_title>span{background:url(https://fbstatic-a.akamaihd.net/rsrc.php/v2/yd/r/Cou7n-nqK52.gif) no-repeat 5px 50%;float:left;padding:5px 0 7px 26px}body.fb_hidden{-webkit-transform:none;height:100%;margin:0;overflow:visible;position:absolute;top:-10000px;left:0;width:100%}.fb_dialog.fb_dialog_mobile.loading{background:url(https://fbstatic-a.akamaihd.net/rsrc.php/v2/ya/r/3rhSv5V8j3o.gif) white no-repeat 50% 50%;min-height:100%;min-width:100%;overflow:hidden;position:absolute;top:0;z-index:10001}.fb_dialog.fb_dialog_mobile.loading.centered{width:auto;height:auto;min-height:initial;min-width:initial;background:none}.fb_dialog.fb_dialog_mobile.loading.centered #fb_dialog_loader_spinner{width:100%}.fb_dialog.fb_dialog_mobile.loading.centered .fb_dialog_content{background:none}.loading.centered #fb_dialog_loader_close{color:#fff;display:block;padding-top:20px;clear:both;font-size:18px}#fb-root #fb_dialog_ipad_overlay{background:rgba(0, 0, 0, .45);position:absolute;bottom:0;left:0;right:0;top:0;width:100%;min-height:100%;z-index:10000}#fb-root #fb_dialog_ipad_overlay.hidden{display:none}.fb_dialog.fb_dialog_mobile.loading iframe{visibility:hidden}.fb_dialog_content .dialog_header{-webkit-box-shadow:white 0 1px 1px -1px inset;background:-webkit-gradient(linear, 0% 0%, 0% 100%, from(#738ABA), to(#2C4987));border-bottom:1px solid;border-color:#1d4088;color:#fff;font:14px Helvetica, sans-serif;font-weight:bold;text-overflow:ellipsis;text-shadow:rgba(0, 30, 84, .296875) 0 -1px 0;vertical-align:middle;white-space:nowrap}.fb_dialog_content .dialog_header table{-webkit-font-smoothing:subpixel-antialiased;height:43px;width:100%}.fb_dialog_content .dialog_header td.header_left{font-size:12px;padding-left:5px;vertical-align:middle;width:60px}.fb_dialog_content .dialog_header td.header_right{font-size:12px;padding-right:5px;vertical-align:middle;width:60px}.fb_dialog_content .touchable_button{background:-webkit-gradient(linear, 0% 0%, 0% 100%, from(#4966A6), color-stop(.5, #355492), to(#2A4887));border:1px solid #2f477a;-webkit-background-clip:padding-box;-webkit-border-radius:3px;-webkit-box-shadow:rgba(0, 0, 0, .117188) 0 1px 1px inset, rgba(255, 255, 255, .167969) 0 1px 0;display:inline-block;margin-top:3px;max-width:85px;line-height:18px;padding:4px 12px;position:relative}.fb_dialog_content .dialog_header .touchable_button input{border:none;background:none;color:#fff;font:12px Helvetica, sans-serif;font-weight:bold;margin:2px -12px;padding:2px 6px 3px 6px;text-shadow:rgba(0, 30, 84, .296875) 0 -1px 0}.fb_dialog_content .dialog_header .header_center{color:#fff;font-size:16px;font-weight:bold;line-height:18px;text-align:center;vertical-align:middle}.fb_dialog_content .dialog_content{background:url(https://fbstatic-a.akamaihd.net/rsrc.php/v2/y9/r/jKEcVPZFk-2.gif) no-repeat 50% 50%;border:1px solid #555;border-bottom:0;border-top:0;height:150px}.fb_dialog_content .dialog_footer{background:#f6f7f8;border:1px solid #555;border-top-color:#ccc;height:40px}#fb_dialog_loader_close{float:left}.fb_dialog.fb_dialog_mobile .fb_dialog_close_button{text-shadow:rgba(0, 30, 84, .296875) 0 -1px 0}.fb_dialog.fb_dialog_mobile .fb_dialog_close_icon{visibility:hidden}#fb_dialog_loader_spinner{animation:rotateSpinner 1.2s linear infinite;background-color:transparent;background-image:url(https://fbstatic-a.akamaihd.net/rsrc.php/v2/yD/r/t-wz8gw1xG1.png);background-repeat:no-repeat;background-position:50% 50%;height:24px;width:24px}@keyframes rotateSpinner{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}
+.fb_iframe_widget{display:inline-block;position:relative}.fb_iframe_widget span{display:inline-block;position:relative;text-align:justify}.fb_iframe_widget iframe{position:absolute}.fb_iframe_widget_fluid_desktop,.fb_iframe_widget_fluid_desktop span,.fb_iframe_widget_fluid_desktop iframe{max-width:100%}.fb_iframe_widget_fluid_desktop iframe{min-width:220px;position:relative}.fb_iframe_widget_lift{z-index:1}.fb_hide_iframes iframe{position:relative;left:-10000px}.fb_iframe_widget_loader{position:relative;display:inline-block}.fb_iframe_widget_fluid{display:inline}.fb_iframe_widget_fluid span{width:100%}.fb_iframe_widget_loader iframe{min-height:32px;z-index:2;zoom:1}.fb_iframe_widget_loader .FB_Loader{background:url(https://fbstatic-a.akamaihd.net/rsrc.php/v2/y9/r/jKEcVPZFk-2.gif) no-repeat;height:32px;width:32px;margin-left:-16px;position:absolute;left:50%;z-index:4}</style></head>
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-5596 node-type-hero-page section-homepage page-panels">
+      <p class="skip-link">
+      <a href="#content-start" class="element-invisible element-focusable">Jump to main content</a>
+    </p>
+        <p id="skip-link">
+      <a href="#block-menu-block-sixteenhundrednav-main" class="element-invisible element-focusable">Jump to navigation</a>
+    </p>
+
+<!-- !$page_manager_control: Only show these things if the page isn't a node under the control of page manager. -->
+<!-- /!$page_manager_control -->
+
+<!-- Main page content -->
+<section id="page"><div id="nav-overlay"></div>
+
+
+
+
+<div class="panelizer-view-mode node node-full node-hero-page node-5596">
+        <div class="panel-display panel-single-col-full-width" id="">
+  <header class="panel-panel panel-header">
+    <div class="panel-pane pane-panels-mini pane-thin-header">
+
+
+
+  <div class="whr-takeover" id="whr-takeover" style="display:none;"></div>
+
+<div class="whr-header-bg">
+  <div class="whr-wrapper">
+    <div class="whr-contact-slogan">
+      <div class="panel-pane pane-page-slogan">
+
+
+
+  the <span class="whr-lead">WHITE HOUSE</span><span class="whr-president">President Barack Obama</span>
+
+  </div>
+
+  <nav class="whr-contact-nav">
+    <div class="menu-block-wrapper menu-block-ctools-sixteenhundred-contact-nav-1 menu-name-sixteenhundred-contact-nav parent-mlid-0 menu-level-1">
+  <ul class="menu"><li class="menu__item is-leaf first leaf menu-mlid-6476 horizontal-1-level-menu--menu-item whr-contact-nav--horizontal-1-level-menu--menu-item odd depth-1 no-children" data-position="1"><a href="http://www.whitehouse.gov/contact" title="Contact the Whitehouse." class="menu__link">Contact Us</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-6481 horizontal-1-level-menu--menu-item whr-contact-nav--horizontal-1-level-menu--menu-item even depth-1 no-children" data-position="2"><a href="http://www.whitehouse.gov/email-updates" title="Get Email Updates." class="menu__link">Get Email Updates</a></li>
+</ul></div>
+  </nav>
+    </div>
+  </div>
+  <div class="whr-navbar">
+    <div class="whr-wrapper">
+      <div class="panel-pane pane-page-logo">
+
+
+
+  <a href="/" rel="home" id="logo" title="Home"><img src="https://www.whitehouse.gov/profiles/forall/modules/custom/gov_whitehouse_www/images/icons/wh_logo_seal.png" alt="Home"></a>
+
+  </div>
+<div id="block-menu-block-sixteenhundrednav-main" class="" tabindex="-1">
+  <div id="main-menu-header" class="clearfix navigation-behaviors-processed">
+    <div id="icon-wrapper">
+      <a href="#" role="tab" id="main-menu-toggle"><i class="fa fa-bars"></i></a>
+    </div>
+  </div>
+  <div id="main-menu-content">
+    <div class="menu-block-wrapper menu-block-ctools-sixteenhundred-main-nav-2 menu-name-sixteenhundred-main-nav parent-mlid-0 menu-level-1">
+  <ul class="menu sf-js-enabled sf-arrows"><li class="first leaf menu-mlid-5816 main-nav--menu-item --main-nav--menu-item odd depth-1 no-children" data-position="1"><a href="https://www.whitehouse.gov" class="no-header">Home<i class="fa fa-angle-down"></i></a></li>
+<li class="expanded menu-mlid-5821 main-nav--menu-item --main-nav--menu-item even depth-1 children children-2" data-position="2"><a href="https://www.whitehouse.gov/briefing-room" class="sf-with-ul">Briefing Room<i class="fa fa-angle-down"></i></a><ul class="menu" style="display: none;"><div class="depth-2-wrapper"><li class="first expanded menu-mlid-5846 main-nav--menu-item --main-nav--menu-item odd depth-2 children children-6 menu-featured menu-featured-descs" data-position="1"><span class="nolink">From the News Room</span><ul class="menu-featured__column" style="display: none;"><li class="first leaf menu-mlid-5856 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="1"><div class="menu-featured__item"><a href="https://www.whitehouse.gov/blog" title="Read the latest blog posts from 1600 Pennsylvania Ave" class="menu-featured__link">Latest News</a><span class="menu-featured__description">Read the latest blog posts from 1600 Pennsylvania Ave</span></div></li>
+<li class="leaf menu-mlid-5861 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="2"><div class="menu-featured__item"><a href="https://www.whitehouse.gov/share" title="Check out the most popular infographics and videos" class="menu-featured__link">Share-Worthy</a><span class="menu-featured__description">Check out the most popular infographics and videos</span></div></li>
+<li class="leaf menu-mlid-5866 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="3"><div class="menu-featured__item"><a href="https://www.whitehouse.gov/photos" title="View the photo of the day and other galleries" class="menu-featured__link">Photos</a><span class="menu-featured__description">View the photo of the day and other galleries</span></div></li>
+</ul><ul class="menu-featured__column" style="display: none;"><li class="leaf menu-mlid-5871 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="4"><div class="menu-featured__item"><a href="https://www.whitehouse.gov/video" title="Watch behind-the-scenes videos and more" class="menu-featured__link">Video Gallery</a><span class="menu-featured__description">Watch behind-the-scenes videos and more</span></div></li>
+<li class="leaf menu-mlid-7071 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="5"><div class="menu-featured__item"><a href="/live" title="Tune in to White House events and statements as they happen" class="menu-featured__link">Live Events</a><span class="menu-featured__description">Tune in to White House events and statements as they happen</span></div></li>
+<li class="last leaf menu-mlid-5881 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="6"><div class="menu-featured__item"><a href="https://www.whitehouse.gov/performances" title="See the lineup of artists and performers at the White House" class="menu-featured__link">Music &amp; Arts Performances</a><span class="menu-featured__description">See the lineup of artists and performers at the White House</span></div></li>
+</ul></li>
+<li class="menu__item is-expanded last expanded menu-mlid-77741 main-nav--menu-item --main-nav--menu-item even depth-2 children children-9" data-position="2"><span class="menu__link nolink">From the Press Office</span><ul class="menu" style="display: none;"><li class="menu__item is-leaf first leaf menu-mlid-5886 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="1"><a href="/briefing-room/weekly-address" class="menu__link">Your Weekly Address</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5891 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="2"><a href="/briefing-room/speeches-and-remarks" class="menu__link">Speeches &amp; Remarks</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5896 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="3"><a href="/briefing-room/press-briefings" class="menu__link">Press Briefings</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5901 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="4"><a href="/briefing-room/statements-and-releases" class="menu__link">Statements &amp; Releases</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5906 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="5"><a href="https://www.whitehouse.gov/blog#today" class="menu__link">White House Schedule</a></li>
+<li class="menu__item is-parent is-leaf leaf has-children menu-mlid-5911 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="6"><a href="/briefing-room/presidential-actions" class="menu__link">Presidential Actions</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5916 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="7"><a href="/briefing-room/legislation" class="menu__link">Legislation</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-142711 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="8"><a href="/briefing-room/nominations-and-appointments" class="menu__link">Nominations &amp; Appointments</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-142716 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="9"><a href="/briefing-room/disclosures" class="menu__link">Disclosures</a></li>
+</ul></li>
+</div></ul></li>
+<li class="expanded menu-mlid-5826 main-nav--menu-item --main-nav--menu-item odd depth-1 children children-4" data-position="3"><a href="https://www.whitehouse.gov/issues" class="sf-with-ul">Issues<i class="fa fa-angle-down"></i></a><ul class="menu" style="display: none;"><div class="depth-2-wrapper"><li class="menu__item is-expanded first expanded menu-mlid-5931 main-nav--menu-item --main-nav--menu-item odd depth-2 children children-6 menu-featured" data-position="1"><span class="menu__link nolink">Popular Topics</span><ul class="menu" style="display: none;"><li class="menu__item is-leaf first leaf menu-mlid-766791 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="1"><a href="https://www.whitehouse.gov/scotus" class="menu__link">Supreme Court Nomination</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-1044606 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="2"><a href="https://www.whitehouse.gov/issues/criminal-justice-reform" class="menu__link">Criminal Justice Reform</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-763306 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="3"><a href="/the-record" class="menu__link">The Record</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-905166 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="4"><a href="https://www.whitehouse.gov/issues/foreign-policy/cuba" class="menu__link">Cuba</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-619156 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="5"><a href="https://www.whitehouse.gov/blog/2015/07/28/presidents-task-force-21st-century-policing-recommendations-print-action" class="menu__link">21st Century Policing</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-5966 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="6"><a href="https://www.whitehouse.gov/issues" class="menu__link">See All</a></li>
+</ul></li>
+<li class="menu__item is-expanded expanded menu-mlid-5936 main-nav--menu-item --main-nav--menu-item even depth-2 children children-8" data-position="2"><span class="menu__link nolink">Top Issues</span><ul class="menu" style="display: none;"><li class="menu__item is-leaf first leaf menu-mlid-5996 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="1"><a href="https://www.whitehouse.gov/issues/civil-rights" class="menu__link">Civil Rights</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5951 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="2"><a href="https://www.whitehouse.gov/climate-change" class="menu__link">Climate Change</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5971 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="3"><a href="https://www.whitehouse.gov/economy" class="menu__link">Economy</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5976 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="4"><a href="https://www.whitehouse.gov/education" class="menu__link">Education</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5981 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="5"><a href="https://www.whitehouse.gov/issues/foreign-policy" class="menu__link">Foreign Policy</a></li>
+<li class="menu__item is-parent is-leaf leaf has-children menu-mlid-5986 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="6"><a href="https://www.whitehouse.gov/healthreform" class="menu__link">Health Care</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-627051 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="7"><a href="https://www.whitehouse.gov/issues/foreign-policy/iran-deal" class="menu__link">Iran Deal</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-35246 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="8"><a href="https://www.whitehouse.gov/issues/immigration/immigration-action" class="menu__link">Immigration Action</a></li>
+</ul></li>
+<li class="menu__item is-expanded expanded menu-mlid-7321 main-nav--menu-item --main-nav--menu-item odd depth-2 children children-8" data-position="3"><span class="menu__link nolink">More</span><ul class="menu" style="display: none;"><li class="menu__item is-leaf first leaf menu-mlid-131696 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="1"><a href="/issues/defense" class="menu__link">Defense</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-91131 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="2"><a href="/issues/disabilities" class="menu__link">Disabilities</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6011 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="3"><a href="https://www.whitehouse.gov/21stcenturygov" class="menu__link">Ethics</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6016 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="4"><a href="https://www.whitehouse.gov/issues/equal-pay" class="menu__link">Equal Pay</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-131731 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="5"><a href="/issues/homeland-security" class="menu__link">Homeland Security</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6066 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="6"><a href="https://www.whitehouse.gov/blog/2016/01/04/live-updates-what-president-doing-keep-guns-out-wrong-hands" class="menu__link">Reducing Gun Violence</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6031 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="7"><a href="https://www.whitehouse.gov/administration/eop/rural-council" class="menu__link">Rural</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-145746 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="8"><a href="/issues/service" class="menu__link">Service</a></li>
+</ul></li>
+<li class="menu__item is-expanded last expanded menu-mlid-5941 main-nav--menu-item --main-nav--menu-item even depth-2 children children-7" data-position="4"><span class="menu__link nolink">More</span><ul class="menu" style="display: none;"><li class="menu__item is-leaf first leaf menu-mlid-132791 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="1"><a href="/issues/seniors-and-social-security" class="menu__link">Seniors &amp; Social Security</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-127311 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="2"><a href="/issues/taxes" class="menu__link">Taxes</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-123561 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="3"><a href="/issues/technology" class="menu__link">Technology</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-93756 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="4"><a href="https://www.whitehouse.gov/trade" class="menu__link">Trade</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6056 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="5"><a href="https://www.whitehouse.gov/issues/urban-and-economic-mobility" class="menu__link">Urban and Economic Mobility</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6061 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="6"><a href="https://www.whitehouse.gov/issues/veterans" class="menu__link">Veterans</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-6071 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="7"><a href="https://www.whitehouse.gov/issues/women" class="menu__link">Women</a></li>
+</ul></li>
+</div></ul></li>
+<li class="expanded menu-mlid-5831 main-nav--menu-item --main-nav--menu-item even depth-1 children children-4" data-position="4"><a href="https://www.whitehouse.gov/administration" class="sf-with-ul">The Administration<i class="fa fa-angle-down"></i></a><ul class="menu" style="display: none;"><div class="depth-2-wrapper"><li class="menu__item is-expanded first expanded menu-mlid-6076 main-nav--menu-item --main-nav--menu-item odd depth-2 children children-8" data-position="1"><span class="menu__link nolink">People</span><ul class="menu" style="display: none;"><li class="menu__item is-leaf first leaf menu-mlid-45996 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="1"><a href="/administration/president-obama" class="menu__link">President Barack Obama</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-46116 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="2"><a href="/administration/vice-president-biden" class="menu__link">Vice President Joe Biden</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-45356 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="3"><a href="/administration/first-lady-michelle-obama" class="menu__link">First Lady Michelle Obama</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-45961 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="4"><a href="/administration/jill-biden" class="menu__link">Dr. Jill Biden</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-35121 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="5"><a href="/administration/cabinet" class="menu__link">The Cabinet</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-89106 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="6"><a href="/administration/eop" class="menu__link">Executive Office of the President</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-89236 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="7"><a href="/administration/senior-leadership" class="menu__link">Senior White House Leadership</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-46031 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="8"><a href="/administration/other-advisory-boards" class="menu__link">Other Advisory Boards</a></li>
+</ul></li>
+<li class="menu__item is-expanded expanded menu-mlid-6081 main-nav--menu-item --main-nav--menu-item even depth-2 children children-6" data-position="2"><span class="menu__link nolink">Executive Offices</span><ul class="menu" style="display: none;"><li class="menu__item is-parent is-leaf first leaf has-children menu-mlid-6126 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="1"><a href="https://www.whitehouse.gov/omb" class="menu__link">Office of Management and Budget</a></li>
+<li class="menu__item is-parent is-leaf leaf has-children menu-mlid-6136 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="2"><a href="https://www.whitehouse.gov/administration/eop/ostp" class="menu__link">Office of Science and Technology Policy</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6141 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="3"><a href="https://www.whitehouse.gov/administration/eop/cea" class="menu__link">Council of Economic Advisers</a></li>
+<li class="menu__item is-parent is-leaf leaf has-children menu-mlid-6146 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="4"><a href="https://www.whitehouse.gov/administration/eop/ceq" class="menu__link">Council on Environmental Quality</a></li>
+<li class="menu__item is-parent is-leaf leaf has-children menu-mlid-204286 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="5"><a href="https://www.whitehouse.gov/administration/eop/nsc/" class="menu__link">National Security Council</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-6151 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="6"><a href="https://www.whitehouse.gov/administration/eop" class="menu__link">See All</a></li>
+</ul></li>
+<li class="menu__item is-expanded expanded menu-mlid-6086 main-nav--menu-item --main-nav--menu-item odd depth-2 children children-6" data-position="3"><span class="menu__link nolink">Initiatives</span><ul class="menu" style="display: none;"><li class="menu__item is-leaf first leaf menu-mlid-6156 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="1"><a href="http://www.letsmove.gov" class="menu__link">Lets Move</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6161 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="2"><a href="https://www.whitehouse.gov/joiningforces" class="menu__link">Joining Forces</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6166 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="3"><a href="https://www.whitehouse.gov/1is2many" class="menu__link">1 is 2 Many</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-233951 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="4"><a href="https://www.whitehouse.gov/reach-higher" class="menu__link">Reach Higher</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-433701 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="5"><a href="https://www.whitehouse.gov/my-brothers-keeper" class="menu__link">My Brother's Keeper</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-6171 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="6"><a href="https://www.whitehouse.gov/startup-america" class="menu__link">Startup America</a></li>
+</ul></li>
+<li class="menu__item is-expanded last expanded menu-mlid-6091 main-nav--menu-item --main-nav--menu-item even depth-2 children children-3" data-position="4"><span class="menu__link nolink">Special Events</span><ul class="menu" style="display: none;"><li class="menu__item is-leaf first leaf menu-mlid-6176 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="1"><a href="https://www.whitehouse.gov/sotu" class="menu__link">State of the Union</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6181 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="2"><a href="https://www.whitehouse.gov/inauguration-2013" class="menu__link">Inauguration</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-6186 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="3"><a href="https://www.whitehouse.gov/medal-of-freedom" class="menu__link">Medal of Freedom</a></li>
+</ul></li>
+</div></ul></li>
+<li class="expanded menu-mlid-5836 main-nav--menu-item --main-nav--menu-item odd depth-1 children children-3" data-position="5"><a href="https://www.whitehouse.gov/participate" class="sf-with-ul">Participate<i class="fa fa-angle-down"></i></a><ul class="menu" style="display: none;"><div class="depth-2-wrapper"><li class="menu__item is-expanded first expanded menu-mlid-6191 main-nav--menu-item --main-nav--menu-item odd depth-2 children children-5" data-position="1"><span class="menu__link nolink">Digital</span><ul class="menu" style="display: none;"><li class="menu__item is-leaf first leaf menu-mlid-6206 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="1"><a href="https://www.whitehouse.gov/engage/social-hub" class="menu__link">Follow Us on Social Media</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-148731 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="2"><a href="/we-the-geeks" class="menu__link">We the Geeks Hangouts</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6226 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="3"><a href="https://www.whitehouse.gov/mobile" class="menu__link">Mobile Apps</a></li>
+<li class="menu__item is-parent is-leaf leaf has-children menu-mlid-148766 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="4"><a href="/developers" class="menu__link">Developer Tools</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-89171 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="5"><a href="https://www.whitehouse.gov/tools" class="menu__link">Tools You Can Use</a></li>
+</ul></li>
+<li class="menu__item is-expanded expanded menu-mlid-6196 main-nav--menu-item --main-nav--menu-item even depth-2 children children-6" data-position="2"><span class="menu__link nolink">Join Us</span><ul class="menu" style="display: none;"><li class="menu__item is-leaf first leaf menu-mlid-108026 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="1"><a href="/participate/tours-and-events" class="menu__link">Tours &amp; Events</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6241 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="2"><a href="https://apply.whitehouse.gov/" class="menu__link">Jobs with the Administration</a></li>
+<li class="menu__item is-parent is-leaf leaf has-children menu-mlid-112596 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="3"><a href="/participate/internships" class="menu__link">Internships</a></li>
+<li class="menu__item is-parent is-leaf leaf has-children menu-mlid-207321 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="4"><a href="/participate/fellows" class="menu__link">White House Fellows</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-152651 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="5"><a href="/innovationfellows" class="menu__link">Presidential Innovation Fellows</a></li>
+<li class="menu__item is-parent is-leaf last leaf has-children menu-mlid-291136 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="6"><a href="/participate/whldp" class="menu__link">Leadership Development Program</a></li>
+</ul></li>
+<li class="menu__item is-expanded last expanded menu-mlid-6201 main-nav--menu-item --main-nav--menu-item odd depth-2 children children-4" data-position="3"><span class="menu__link nolink">Speak Out</span><ul class="menu" style="display: none;"><li class="menu__item is-leaf first leaf menu-mlid-6261 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="1"><a href="https://petitions.whitehouse.gov" class="menu__link">We the People Petitions</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6266 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="2"><a href="https://www.whitehouse.gov/contact" class="menu__link">Contact the White House</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6271 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="3"><a href="https://www.whitehouse.gov/citizensmedal/criteria" class="menu__link">Citizens Medal</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-6281 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="4"><a href="https://www.whitehouse.gov/champions" class="menu__link">Champions of Change</a></li>
+</ul></li>
+</div></ul></li>
+<li class="last expanded menu-mlid-5841 main-nav--menu-item --main-nav--menu-item even depth-1 children children-3" data-position="6"><a href="https://www.whitehouse.gov/1600" class="sf-with-ul">1600 Penn<i class="fa fa-angle-down"></i></a><ul class="menu" style="display: none;"><div class="depth-2-wrapper"><li class="menu__item is-expanded first expanded menu-mlid-6291 main-nav--menu-item --main-nav--menu-item odd depth-2 children children-6" data-position="1"><span class="menu__link nolink">Inside the White House</span><ul class="menu" style="display: none;"><li class="menu__item is-leaf first leaf menu-mlid-6306 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="1"><a href="https://www.whitehouse.gov/about/inside-white-house/interactive-tour" class="menu__link">Interactive Tour</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6311 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="2"><a href="https://www.whitehouse.gov/about/inside-white-house/west-wing-tour" class="menu__link">West Wing Tour</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6316 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="3"><a href="https://www.whitehouse.gov/about/inside-white-house/video-series" class="menu__link">Video Series</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6321 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="4"><a href="https://www.whitehouse.gov/about/inside-white-house/art" class="menu__link">Décor and Art</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6326 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="5"><a href="https://www.whitehouse.gov/about/inside-white-house/holidays" class="menu__link">Holidays</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-6336 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="6"><a href="https://www.whitehouse.gov/about/inside-white-house" class="menu__link">See All</a></li>
+</ul></li>
+<li class="menu__item is-expanded expanded menu-mlid-6296 main-nav--menu-item --main-nav--menu-item even depth-2 children children-6" data-position="2"><span class="menu__link nolink">History &amp; Grounds</span><ul class="menu" style="display: none;"><li class="menu__item is-leaf first leaf menu-mlid-86676 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="1"><a href="/1600/Presidents" class="menu__link">Presidents</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-86891 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="2"><a href="/1600/first-ladies" class="menu__link">First Ladies</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-93186 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="3"><a href="/1600/vp-residence" class="menu__link">The Vice President's Residence &amp; Office</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-93191 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="4"><a href="/1600/eeob" class="menu__link">Eisenhower Executive Office Building</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-93181 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="5"><a href="/1600/camp-david" class="menu__link">Camp David</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-91831 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="6"><a href="/1600/air-force-one" class="menu__link">Air Force One</a></li>
+</ul></li>
+<li class="menu__item is-expanded last expanded menu-mlid-6301 main-nav--menu-item --main-nav--menu-item odd depth-2 children children-8" data-position="3"><span class="menu__link nolink">Our Government</span><ul class="menu" style="display: none;"><li class="menu__item is-leaf first leaf menu-mlid-93196 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="1"><a href="/1600/executive-branch" class="menu__link">The Executive Branch</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-93201 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="2"><a href="/1600/legislative-branch" class="menu__link">The Legislative Branch</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-93206 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="3"><a href="/1600/judicial-branch" class="menu__link">The Judicial Branch</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-93211 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="4"><a href="/1600/constitution" class="menu__link">The Constitution</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-93216 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="5"><a href="/1600/federal-agencies-and-commissions" class="menu__link">Federal Agencies &amp; Commissions</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-93231 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="6"><a href="/1600/elections-and-voting" class="menu__link">Elections &amp; Voting</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-93226 main-nav--menu-item --main-nav--menu-item odd depth-3 no-children" data-position="7"><a href="/1600/state-and-local-government" class="menu__link">State &amp; Local Government</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-93221 main-nav--menu-item --main-nav--menu-item even depth-3 no-children" data-position="8"><a href="/1600/resources" class="menu__link">Resources</a></li>
+</ul></li>
+</div></ul></li>
+</ul></div>
+  </div>
+</div>
+<div class="panel-pane pane-block pane-search-form sitewide-header--search-form">
+
+
+
+  <form action="//search.whitehouse.gov/search" method="get" id="search-block-form" accept-charset="UTF-8"><div><div class="container-inline">
+      <h2 class="element-invisible">Search form</h2>
+    <div class="form-item form-type-textfield form-item-query">
+  <label class="element-invisible" for="edit-search-block-form--2">Search </label>
+ <input title="Enter the terms you wish to search for." type="text" id="edit-search-block-form--2" name="query" value="" size="15" maxlength="128" class="form-text">
+</div>
+<div class="form-actions form-wrapper" id="edit-actions"><input type="submit" id="edit-submit" name="op" value="Search" class="form-submit"></div><input type="hidden" name="affiliate" value="wh">
+</div>
+</div></form>
+
+  </div>
+    </div>
+  </div>
+</div>
+<div class="whr-wrapper">
+  </div>
+
+
+
+  </div>
+<div class="panel-pane pane-content-anchor-pane">
+
+
+
+  <a id="content-start" name="content-start" tabindex="-1"></a>
+
+  </div>
+<div class="panel-pane pane-entity-field pane-node-field-hero-queue">
+
+
+
+  <div class="field field-name-field-hero-queue field-type-entityreference field-label-hidden"><div class="field-items"><div class="field-item even"><article class="node-286231 node node-hero view-mode-default clearfix" about="/node/286231" typeof="sioc:Item foaf:Document">
+  <div class="wrapper hero-wrapper clearfix">
+
+    <div class="wrapper image-wrapper">
+      <div id="field-hero-image" class="field field-image" style="background-color: #ffffff; ">
+        <div class="field field-name-field-hero-bg-image field-type-image field-label-hidden"><div class="field-items"><div class="field-item even"><img data-desktop="https://www.whitehouse.gov/sites/whitehouse.gov/files/hero-backgrounds/photo_2560_0.jpg" typeof="foaf:Image" src="https://www.whitehouse.gov/sites/whitehouse.gov/files/hero-backgrounds/photo_2560_0.jpg" width="2560" height="920" alt="Meet President Obama's Supreme Court Nominee"></div></div></div>      </div>
+
+
+    </div>
+
+    <div class="wrapper wrapper-outer wrapper-caption-outer">
+      <div class="wrapper wrapper-inner wrapper-caption">
+        <div id="hero-caption" class="hero-content-box hero-caption
+        caption-position-left caption-no-background " style="max-width: 400px; max-height: 280px; ">
+        <div class="field field-name-field-hero-content-box field-type-text-long field-label-hidden"><div class="field-items"><div class="field-item even"><p class="superheader"><span style="color:#FFFFFF"><span style="font-family:calibri,sans-serif; font-size:14px; line-height:normal; orphans:2; text-align:-webkit-auto; widows:2">The Supreme Court</span></span></p>
+
+<h1 class="formal"><span style="color:#ffb400">Meet President Obama's Supreme Court Nominee</span></h1>
+
+<p><span style="color:#FFFFFF">President Obama has announced<strong> Chief Judge Merrick Garland</strong><br>
+as his nominee for Supreme Court Justice.&nbsp;</span><br>
+<br>
+<span style="color:#ffb400"><span class="linkbox"><a class="linkbox-title btn btn-blue" href="https://www.whitehouse.gov/scotus" target="_self">Learn about the nominee</a></span></span></p>
+
+<p>&nbsp;</p>
+
+<p>&nbsp;</p>
+
+<p>&nbsp;</p>
+
+<p>&nbsp;</p>
+
+<p>&nbsp;</p>
+
+<p></p>
+</div></div></div>        <div class="caption-background" style="background-color: transparent;">
+        </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <span property="dc:title" content="Scotus Wednesday 11:15" class="rdf-meta element-hidden"></span><span property="sioc:num_replies" content="0" datatype="xsd:integer" class="rdf-meta element-hidden"></span>
+</article>
+</div></div></div>
+
+  </div>
+  </header>
+    <div class="panel-panel panel-wrapper panel-col-section-all hero-page-content">
+      <div class="panel-panel panel-col panel-col-section-content-first">
+        <div class="colorbar" style="border-top: 6px solid #880000"></div><div class="panel-pane pane-fieldable-panels-pane pane-fpid-251 pane-bundle-curated-content-pane">
+
+
+
+  <div class="fieldable-panels-pane prominence-primary clearfix">
+    <div class="field field-name-field-currated-content field-type-entityreference field-label-hidden"><div class="field-items"><div class="field-item even">
+<article class="node-290016 node node-tout view-mode-full clearfix" about="/node/290016" typeof="sioc:Item foaf:Document">
+
+      <a class="tout-wrapper clearfix" href="https://www.whitehouse.gov/blog/2016/04/19/discover-americas-great-outdoors-during-national-park-week">
+
+
+      <div class="tout-image">
+        <div class="field field-name-field-tout-image field-type-image field-label-hidden"><div class="field-items"><div class="field-item even"><img typeof="foaf:Image" src="https://www.whitehouse.gov/sites/whitehouse.gov/files/tout_images/parkstout.jpg" width="860" height="484" alt="Find Your Park"></div></div></div>      </div>
+
+      <div class="tout-text">
+        <div class="field field-name-field-super-header field-type-text field-label-hidden"><div class="field-items"><div class="field-item even">Find Your Park</div></div></div>
+                  <h2 class="node__title node-title">Explore America's great outdoors during national park week.</h2>
+              </div>
+
+      </a>
+
+  <span property="dc:title" content="Explore America's great outdoors during national park week." class="rdf-meta element-hidden"></span><span property="sioc:num_replies" content="0" datatype="xsd:integer" class="rdf-meta element-hidden"></span>
+</article>
+</div><div class="field-item odd">
+<article class="node-290141 node node-tout view-mode-full clearfix" about="/node/290141" typeof="sioc:Item foaf:Document">
+
+      <a class="tout-wrapper clearfix" href="http://petitions.whitehouse.gov">
+
+
+      <div class="tout-image">
+        <div class="field field-name-field-tout-image field-type-image field-label-hidden"><div class="field-items"><div class="field-item even"><img typeof="foaf:Image" src="https://www.whitehouse.gov/sites/whitehouse.gov/files/tout_images/wtpTout_0.jpg" width="860" height="484" alt="We the People"></div></div></div>      </div>
+
+      <div class="tout-text">
+        <div class="field field-name-field-super-header field-type-text field-label-hidden"><div class="field-items"><div class="field-item even">We the People</div></div></div>
+                  <h2 class="node__title node-title">Check out a new and improved way to engage your government.</h2>
+              </div>
+
+      </a>
+
+  <span property="dc:title" content="Check out a new and improved way to engage your government." class="rdf-meta element-hidden"></span><span property="sioc:num_replies" content="0" datatype="xsd:integer" class="rdf-meta element-hidden"></span>
+</article>
+</div></div></div></div>
+
+
+  </div>
+      </div>
+
+              <div class="panel-panel panel-col panel-col-section-content-second">
+          <div class="panel-pane pane-fieldable-panels-pane pane-fpid-261 pane-bundle-curated-content-pane">
+
+        <h2 class="pane-title">Get Plugged In</h2>
+
+
+  <div class="fieldable-panels-pane prominence-secondary clearfix">
+    <div class="field field-name-field-currated-content field-type-entityreference field-label-hidden"><div class="field-items"><div class="field-item even">
+<article class="node-5971 node node-tout view-mode-full clearfix" about="/node/5971" typeof="sioc:Item foaf:Document">
+
+      <a class="tout-wrapper clearfix" href="https://www.whitehouse.gov/schedule">
+
+
+      <div class="tout-image">
+        <div class="field field-name-field-tout-image field-type-image field-label-hidden"><div class="field-items"><div class="field-item even"><img typeof="foaf:Image" src="https://www.whitehouse.gov/sites/whitehouse.gov/files/tout_images/presidents_schedule_tout_02.jpg" width="860" height="484" alt="President Barack Obama meets with Chase Cushman, Director of Scheduling and Advance, in the Oval Office, May 22, 2015. (Official White House Photo by Pete Souza)"></div></div></div>      </div>
+
+      <div class="tout-text">
+        <div class="field field-name-field-super-header field-type-text field-label-hidden"><div class="field-items"><div class="field-item even">The President's Daily Schedule</div></div></div>
+                  <h2 class="node__title node-title">See the President and Vice President’s daily public schedules online.</h2>
+              </div>
+
+      </a>
+
+  <span property="dc:title" content="See the President and Vice President’s daily public schedules online." class="rdf-meta element-hidden"></span><span property="sioc:num_replies" content="0" datatype="xsd:integer" class="rdf-meta element-hidden"></span>
+</article>
+</div><div class="field-item odd">
+<article class="node-6446 node node-tout view-mode-full clearfix" about="/node/6446" typeof="sioc:Item foaf:Document">
+
+      <a class="tout-wrapper clearfix" href="https://www.whitehouse.gov/contact">
+
+
+      <div class="tout-image">
+        <div class="field field-name-field-tout-image field-type-image field-label-hidden"><div class="field-items"><div class="field-item even"><img typeof="foaf:Image" src="https://www.whitehouse.gov/sites/whitehouse.gov/files/tout_images/potus_phone_tout.jpg" width="860" height="484" alt="President Obama smiles while speaking on the phone in the Oval Office"></div></div></div>      </div>
+
+      <div class="tout-text">
+        <div class="field field-name-field-super-header field-type-text field-label-hidden"><div class="field-items"><div class="field-item even">Get in touch with us</div></div></div>
+                  <h2 class="node__title node-title">Share your questions or your story with President Obama.  </h2>
+              </div>
+
+      </a>
+
+  <span property="dc:title" content="Share your questions or your story with President Obama.  " class="rdf-meta element-hidden"></span><span property="sioc:num_replies" content="0" datatype="xsd:integer" class="rdf-meta element-hidden"></span>
+</article>
+</div><div class="field-item even">
+<article class="node-5976 node node-tout view-mode-full clearfix" about="/node/5976" typeof="sioc:Item foaf:Document">
+
+      <a class="tout-wrapper clearfix" href="https://www.whitehouse.gov/photos">
+
+
+      <div class="tout-image">
+        <div class="field field-name-field-tout-image field-type-image field-label-hidden"><div class="field-items"><div class="field-item even"><img typeof="foaf:Image" src="https://www.whitehouse.gov/sites/whitehouse.gov/files/tout_images/POD_03022016_tout.jpg" width="860" height="484" alt="A sample of images from the White House Photo Office's Past Photo Picks of The Day"></div></div></div>      </div>
+
+      <div class="tout-text">
+        <div class="field field-name-field-super-header field-type-text field-label-hidden"><div class="field-items"><div class="field-item even">Photo of the Day</div></div></div>
+                  <h2 class="node__title node-title">Explore the White House Photo Office's past images of the day.</h2>
+              </div>
+
+      </a>
+
+  <span property="dc:title" content="Explore the White House Photo Office's past images of the day." class="rdf-meta element-hidden"></span><span property="sioc:num_replies" content="0" datatype="xsd:integer" class="rdf-meta element-hidden"></span>
+</article>
+</div></div></div></div>
+
+
+  </div>
+        </div>
+
+          </div>
+  <footer class="panel-panel panel-footer">
+
+  <footer class="panel-pane pane-panels-mini pane-default-sitewide-footer sitewide-footer">
+    <div class="sitewide-footer__wrapper">
+
+  <nav class="sitewide-footer--social-nav">
+    <div class="menu-block-wrapper menu-block-ctools-sixteenhundred-social-nav-1 menu-name-sixteenhundred-social-nav parent-mlid-0 menu-level-1">
+  <ul class="menu"><li class="menu__item is-leaf first leaf menu-mlid-6411 horizontal-social-menu--menu-item sitewide-footer--social-nav--horizontal-social-menu--menu-item odd depth-1 no-children" data-position="1"><a href="http://twitter.com/whitehouse" class="menu__link" title="Follow the Whitehouse on Twitter."><span class="fa fa-twitter"></span><span class="element-invisible">Twitter</span></a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6416 horizontal-social-menu--menu-item sitewide-footer--social-nav--horizontal-social-menu--menu-item even depth-1 no-children" data-position="2"><a href="http://instagram.com/whitehouse" class="menu__link" title="See the Whitehouse on Instagram."><span class="fa fa-instagram"></span><span class="element-invisible">Instagram</span></a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6421 horizontal-social-menu--menu-item sitewide-footer--social-nav--horizontal-social-menu--menu-item odd depth-1 no-children" data-position="3"><a href="http://facebook.com/whitehouse" class="menu__link" title="Like the Whitehouse on Facebook."><span class="fa fa-facebook"></span><span class="element-invisible">Facebook</span></a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6426 horizontal-social-menu--menu-item sitewide-footer--social-nav--horizontal-social-menu--menu-item even depth-1 no-children" data-position="4"><a href="https://plus.google.com/+whitehouse" class="menu__link" title="Follow the Whitehouse on Google+."><span class="fa fa-google-plus-square"></span><span class="element-invisible">Google+</span></a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6431 horizontal-social-menu--menu-item sitewide-footer--social-nav--horizontal-social-menu--menu-item odd depth-1 no-children" data-position="5"><a href="http://www.youtube.com/user/whitehouse" title="Visit The Whitehouse Channel on Youtube." class="menu__link"><span class="fa fa-youtube-play"></span><span class="element-invisible">Youtube</span></a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6436 horizontal-social-menu--menu-item sitewide-footer--social-nav--horizontal-social-menu--menu-item even depth-1 no-children" data-position="6"><a href="http://www.whitehouse.gov/engage" class="menu__link" title="More ways to engage with the Whitehouse."><span class="fa fa-plus"></span><span class="element-invisible">More ways to engage</span></a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6441 horizontal-social-menu--menu-item sitewide-footer--social-nav--horizontal-social-menu--menu-item odd depth-1 no-children" data-position="7"><a href="http://www.whitehouse.gov/contact" class="menu__link sitewide-footer--social-nav__border sitewide-footer--social-nav__contact-link" title="Contact the Whitehouse."><span class="fa fa-comment"></span><span class="element-invisible">Contact Us</span></a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-6446 horizontal-social-menu--menu-item sitewide-footer--social-nav--horizontal-social-menu--menu-item even depth-1 no-children" data-position="8"><a href="http://www.whitehouse.gov/email-updates" class="menu__link sitewide-footer--social-nav__contact-link" title="Email the Whitehouse."><span class="fa fa-envelope"></span><span class="element-invisible">Email</span></a></li>
+</ul></div>
+  </nav>
+
+  <nav class="panel-pane pane-menu-tree pane-sixteenhundred-main-nav sitewide-footer--main-nav horizontal-3-level-menu">
+    <div class="menu-block-wrapper menu-block-ctools-sixteenhundred-main-nav-1 menu-name-sixteenhundred-main-nav parent-mlid-0 menu-level-1">
+  <ul class="menu"><li class="menu__item is-leaf first leaf menu-mlid-5816 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-1 horizontal-3-level-menu__top-item odd depth-1 no-children" data-position="1"><a href="https://www.whitehouse.gov" class="menu__link no-header">Home</a></li>
+<li class="menu__item is-expanded expanded menu-mlid-5821 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-1 even depth-1 children children-2" data-position="2"><a href="https://www.whitehouse.gov/briefing-room" class="menu__link">Briefing Room</a><ul class="menu"><li class="menu__item is-expanded first expanded menu-mlid-5846 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-2 odd depth-2 children children-6 menu-featured menu-featured-descs" data-position="1"><span class="menu__link nolink">From the News Room</span><ul class="menu"><li class="menu__item is-leaf first leaf menu-mlid-5856 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="1"><a href="https://www.whitehouse.gov/blog" title="Read the latest blog posts from 1600 Pennsylvania Ave" class="menu__link">Latest News</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5861 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="2"><a href="https://www.whitehouse.gov/share" title="Check out the most popular infographics and videos" class="menu__link">Share-Worthy</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5866 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="3"><a href="https://www.whitehouse.gov/photos" title="View the photo of the day and other galleries" class="menu__link">Photos</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5871 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="4"><a href="https://www.whitehouse.gov/video" title="Watch behind-the-scenes videos and more" class="menu__link">Video Gallery</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-7071 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="5"><a href="/live" title="Tune in to White House events and statements as they happen" class="menu__link">Live Events</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-5881 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="6"><a href="https://www.whitehouse.gov/performances" title="See the lineup of artists and performers at the White House" class="menu__link">Music &amp; Arts Performances</a></li>
+</ul></li>
+<li class="menu__item is-expanded last expanded menu-mlid-77741 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-2 even depth-2 children children-9" data-position="2"><span class="menu__link nolink">From the Press Office</span><ul class="menu"><li class="menu__item is-leaf first leaf menu-mlid-5886 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="1"><a href="/briefing-room/weekly-address" class="menu__link">Your Weekly Address</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5891 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="2"><a href="/briefing-room/speeches-and-remarks" class="menu__link">Speeches &amp; Remarks</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5896 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="3"><a href="/briefing-room/press-briefings" class="menu__link">Press Briefings</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5901 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="4"><a href="/briefing-room/statements-and-releases" class="menu__link">Statements &amp; Releases</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5906 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="5"><a href="https://www.whitehouse.gov/blog#today" class="menu__link">White House Schedule</a></li>
+<li class="menu__item is-parent is-leaf leaf has-children menu-mlid-5911 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="6"><a href="/briefing-room/presidential-actions" class="menu__link">Presidential Actions</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5916 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="7"><a href="/briefing-room/legislation" class="menu__link">Legislation</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-142711 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="8"><a href="/briefing-room/nominations-and-appointments" class="menu__link">Nominations &amp; Appointments</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-142716 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="9"><a href="/briefing-room/disclosures" class="menu__link">Disclosures</a></li>
+</ul></li>
+</ul></li>
+<li class="menu__item is-expanded expanded menu-mlid-5826 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-1 odd depth-1 children children-4" data-position="3"><a href="https://www.whitehouse.gov/issues" class="menu__link">Issues</a><ul class="menu"><li class="menu__item is-expanded first expanded menu-mlid-5931 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-2 odd depth-2 children children-6 menu-featured" data-position="1"><span class="menu__link nolink">Popular Topics</span><ul class="menu"><li class="menu__item is-leaf first leaf menu-mlid-766791 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="1"><a href="https://www.whitehouse.gov/scotus" class="menu__link">Supreme Court Nomination</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-1044606 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="2"><a href="https://www.whitehouse.gov/issues/criminal-justice-reform" class="menu__link">Criminal Justice Reform</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-763306 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="3"><a href="/the-record" class="menu__link">The Record</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-905166 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="4"><a href="https://www.whitehouse.gov/issues/foreign-policy/cuba" class="menu__link">Cuba</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-619156 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="5"><a href="https://www.whitehouse.gov/blog/2015/07/28/presidents-task-force-21st-century-policing-recommendations-print-action" class="menu__link">21st Century Policing</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-5966 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="6"><a href="https://www.whitehouse.gov/issues" class="menu__link">See All</a></li>
+</ul></li>
+<li class="menu__item is-expanded expanded menu-mlid-5936 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-2 even depth-2 children children-8" data-position="2"><span class="menu__link nolink">Top Issues</span><ul class="menu"><li class="menu__item is-leaf first leaf menu-mlid-5996 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="1"><a href="https://www.whitehouse.gov/issues/civil-rights" class="menu__link">Civil Rights</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5951 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="2"><a href="https://www.whitehouse.gov/climate-change" class="menu__link">Climate Change</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5971 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="3"><a href="https://www.whitehouse.gov/economy" class="menu__link">Economy</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5976 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="4"><a href="https://www.whitehouse.gov/education" class="menu__link">Education</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-5981 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="5"><a href="https://www.whitehouse.gov/issues/foreign-policy" class="menu__link">Foreign Policy</a></li>
+<li class="menu__item is-parent is-leaf leaf has-children menu-mlid-5986 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="6"><a href="https://www.whitehouse.gov/healthreform" class="menu__link">Health Care</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-627051 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="7"><a href="https://www.whitehouse.gov/issues/foreign-policy/iran-deal" class="menu__link">Iran Deal</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-35246 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="8"><a href="https://www.whitehouse.gov/issues/immigration/immigration-action" class="menu__link">Immigration Action</a></li>
+</ul></li>
+<li class="menu__item is-expanded expanded menu-mlid-7321 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-2 odd depth-2 children children-8" data-position="3"><span class="menu__link nolink">More</span><ul class="menu"><li class="menu__item is-leaf first leaf menu-mlid-131696 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="1"><a href="/issues/defense" class="menu__link">Defense</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-91131 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="2"><a href="/issues/disabilities" class="menu__link">Disabilities</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6011 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="3"><a href="https://www.whitehouse.gov/21stcenturygov" class="menu__link">Ethics</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6016 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="4"><a href="https://www.whitehouse.gov/issues/equal-pay" class="menu__link">Equal Pay</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-131731 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="5"><a href="/issues/homeland-security" class="menu__link">Homeland Security</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6066 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="6"><a href="https://www.whitehouse.gov/blog/2016/01/04/live-updates-what-president-doing-keep-guns-out-wrong-hands" class="menu__link">Reducing Gun Violence</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6031 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="7"><a href="https://www.whitehouse.gov/administration/eop/rural-council" class="menu__link">Rural</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-145746 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="8"><a href="/issues/service" class="menu__link">Service</a></li>
+</ul></li>
+<li class="menu__item is-expanded last expanded menu-mlid-5941 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-2 even depth-2 children children-7" data-position="4"><span class="menu__link nolink">More</span><ul class="menu"><li class="menu__item is-leaf first leaf menu-mlid-132791 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="1"><a href="/issues/seniors-and-social-security" class="menu__link">Seniors &amp; Social Security</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-127311 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="2"><a href="/issues/taxes" class="menu__link">Taxes</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-123561 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="3"><a href="/issues/technology" class="menu__link">Technology</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-93756 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="4"><a href="https://www.whitehouse.gov/trade" class="menu__link">Trade</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6056 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="5"><a href="https://www.whitehouse.gov/issues/urban-and-economic-mobility" class="menu__link">Urban and Economic Mobility</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6061 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="6"><a href="https://www.whitehouse.gov/issues/veterans" class="menu__link">Veterans</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-6071 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="7"><a href="https://www.whitehouse.gov/issues/women" class="menu__link">Women</a></li>
+</ul></li>
+</ul></li>
+<li class="menu__item is-expanded expanded menu-mlid-5831 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-1 even depth-1 children children-4" data-position="4"><a href="https://www.whitehouse.gov/administration" class="menu__link">The Administration</a><ul class="menu"><li class="menu__item is-expanded first expanded menu-mlid-6076 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-2 odd depth-2 children children-8" data-position="1"><span class="menu__link nolink">People</span><ul class="menu"><li class="menu__item is-leaf first leaf menu-mlid-45996 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="1"><a href="/administration/president-obama" class="menu__link">President Barack Obama</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-46116 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="2"><a href="/administration/vice-president-biden" class="menu__link">Vice President Joe Biden</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-45356 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="3"><a href="/administration/first-lady-michelle-obama" class="menu__link">First Lady Michelle Obama</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-45961 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="4"><a href="/administration/jill-biden" class="menu__link">Dr. Jill Biden</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-35121 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="5"><a href="/administration/cabinet" class="menu__link">The Cabinet</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-89106 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="6"><a href="/administration/eop" class="menu__link">Executive Office of the President</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-89236 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="7"><a href="/administration/senior-leadership" class="menu__link">Senior White House Leadership</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-46031 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="8"><a href="/administration/other-advisory-boards" class="menu__link">Other Advisory Boards</a></li>
+</ul></li>
+<li class="menu__item is-expanded expanded menu-mlid-6081 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-2 even depth-2 children children-6" data-position="2"><span class="menu__link nolink">Executive Offices</span><ul class="menu"><li class="menu__item is-parent is-leaf first leaf has-children menu-mlid-6126 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="1"><a href="https://www.whitehouse.gov/omb" class="menu__link">Office of Management and Budget</a></li>
+<li class="menu__item is-parent is-leaf leaf has-children menu-mlid-6136 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="2"><a href="https://www.whitehouse.gov/administration/eop/ostp" class="menu__link">Office of Science and Technology Policy</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6141 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="3"><a href="https://www.whitehouse.gov/administration/eop/cea" class="menu__link">Council of Economic Advisers</a></li>
+<li class="menu__item is-parent is-leaf leaf has-children menu-mlid-6146 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="4"><a href="https://www.whitehouse.gov/administration/eop/ceq" class="menu__link">Council on Environmental Quality</a></li>
+<li class="menu__item is-parent is-leaf leaf has-children menu-mlid-204286 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="5"><a href="https://www.whitehouse.gov/administration/eop/nsc/" class="menu__link">National Security Council</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-6151 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="6"><a href="https://www.whitehouse.gov/administration/eop" class="menu__link">See All</a></li>
+</ul></li>
+<li class="menu__item is-expanded expanded menu-mlid-6086 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-2 odd depth-2 children children-6" data-position="3"><span class="menu__link nolink">Initiatives</span><ul class="menu"><li class="menu__item is-leaf first leaf menu-mlid-6156 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="1"><a href="http://www.letsmove.gov" class="menu__link">Lets Move</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6161 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="2"><a href="https://www.whitehouse.gov/joiningforces" class="menu__link">Joining Forces</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6166 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="3"><a href="https://www.whitehouse.gov/1is2many" class="menu__link">1 is 2 Many</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-233951 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="4"><a href="https://www.whitehouse.gov/reach-higher" class="menu__link">Reach Higher</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-433701 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="5"><a href="https://www.whitehouse.gov/my-brothers-keeper" class="menu__link">My Brother's Keeper</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-6171 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="6"><a href="https://www.whitehouse.gov/startup-america" class="menu__link">Startup America</a></li>
+</ul></li>
+<li class="menu__item is-expanded last expanded menu-mlid-6091 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-2 even depth-2 children children-3" data-position="4"><span class="menu__link nolink">Special Events</span><ul class="menu"><li class="menu__item is-leaf first leaf menu-mlid-6176 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="1"><a href="https://www.whitehouse.gov/sotu" class="menu__link">State of the Union</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6181 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="2"><a href="https://www.whitehouse.gov/inauguration-2013" class="menu__link">Inauguration</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-6186 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="3"><a href="https://www.whitehouse.gov/medal-of-freedom" class="menu__link">Medal of Freedom</a></li>
+</ul></li>
+</ul></li>
+<li class="menu__item is-expanded expanded menu-mlid-5836 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-1 odd depth-1 children children-3" data-position="5"><a href="https://www.whitehouse.gov/participate" class="menu__link">Participate</a><ul class="menu"><li class="menu__item is-expanded first expanded menu-mlid-6191 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-2 odd depth-2 children children-5" data-position="1"><span class="menu__link nolink">Digital</span><ul class="menu"><li class="menu__item is-leaf first leaf menu-mlid-6206 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="1"><a href="https://www.whitehouse.gov/engage/social-hub" class="menu__link">Follow Us on Social Media</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-148731 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="2"><a href="/we-the-geeks" class="menu__link">We the Geeks Hangouts</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6226 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="3"><a href="https://www.whitehouse.gov/mobile" class="menu__link">Mobile Apps</a></li>
+<li class="menu__item is-parent is-leaf leaf has-children menu-mlid-148766 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="4"><a href="/developers" class="menu__link">Developer Tools</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-89171 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="5"><a href="https://www.whitehouse.gov/tools" class="menu__link">Tools You Can Use</a></li>
+</ul></li>
+<li class="menu__item is-expanded expanded menu-mlid-6196 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-2 even depth-2 children children-6" data-position="2"><span class="menu__link nolink">Join Us</span><ul class="menu"><li class="menu__item is-leaf first leaf menu-mlid-108026 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="1"><a href="/participate/tours-and-events" class="menu__link">Tours &amp; Events</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6241 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="2"><a href="https://apply.whitehouse.gov/" class="menu__link">Jobs with the Administration</a></li>
+<li class="menu__item is-parent is-leaf leaf has-children menu-mlid-112596 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="3"><a href="/participate/internships" class="menu__link">Internships</a></li>
+<li class="menu__item is-parent is-leaf leaf has-children menu-mlid-207321 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="4"><a href="/participate/fellows" class="menu__link">White House Fellows</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-152651 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="5"><a href="/innovationfellows" class="menu__link">Presidential Innovation Fellows</a></li>
+<li class="menu__item is-parent is-leaf last leaf has-children menu-mlid-291136 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="6"><a href="/participate/whldp" class="menu__link">Leadership Development Program</a></li>
+</ul></li>
+<li class="menu__item is-expanded last expanded menu-mlid-6201 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-2 odd depth-2 children children-4" data-position="3"><span class="menu__link nolink">Speak Out</span><ul class="menu"><li class="menu__item is-leaf first leaf menu-mlid-6261 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="1"><a href="https://petitions.whitehouse.gov" class="menu__link">We the People Petitions</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6266 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="2"><a href="https://www.whitehouse.gov/contact" class="menu__link">Contact the White House</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6271 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="3"><a href="https://www.whitehouse.gov/citizensmedal/criteria" class="menu__link">Citizens Medal</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-6281 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="4"><a href="https://www.whitehouse.gov/champions" class="menu__link">Champions of Change</a></li>
+</ul></li>
+</ul></li>
+<li class="menu__item is-expanded last expanded menu-mlid-5841 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-1 even depth-1 children children-3" data-position="6"><a href="https://www.whitehouse.gov/1600" class="menu__link">1600 Penn</a><ul class="menu"><li class="menu__item is-expanded first expanded menu-mlid-6291 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-2 odd depth-2 children children-6" data-position="1"><span class="menu__link nolink">Inside the White House</span><ul class="menu"><li class="menu__item is-leaf first leaf menu-mlid-6306 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="1"><a href="https://www.whitehouse.gov/about/inside-white-house/interactive-tour" class="menu__link">Interactive Tour</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6311 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="2"><a href="https://www.whitehouse.gov/about/inside-white-house/west-wing-tour" class="menu__link">West Wing Tour</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6316 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="3"><a href="https://www.whitehouse.gov/about/inside-white-house/video-series" class="menu__link">Video Series</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6321 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="4"><a href="https://www.whitehouse.gov/about/inside-white-house/art" class="menu__link">Décor and Art</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6326 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="5"><a href="https://www.whitehouse.gov/about/inside-white-house/holidays" class="menu__link">Holidays</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-6336 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="6"><a href="https://www.whitehouse.gov/about/inside-white-house" class="menu__link">See All</a></li>
+</ul></li>
+<li class="menu__item is-expanded expanded menu-mlid-6296 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-2 even depth-2 children children-6" data-position="2"><span class="menu__link nolink">History &amp; Grounds</span><ul class="menu"><li class="menu__item is-leaf first leaf menu-mlid-86676 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="1"><a href="/1600/Presidents" class="menu__link">Presidents</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-86891 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="2"><a href="/1600/first-ladies" class="menu__link">First Ladies</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-93186 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="3"><a href="/1600/vp-residence" class="menu__link">The Vice President's Residence &amp; Office</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-93191 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="4"><a href="/1600/eeob" class="menu__link">Eisenhower Executive Office Building</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-93181 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="5"><a href="/1600/camp-david" class="menu__link">Camp David</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-91831 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="6"><a href="/1600/air-force-one" class="menu__link">Air Force One</a></li>
+</ul></li>
+<li class="menu__item is-expanded last expanded menu-mlid-6301 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-2 odd depth-2 children children-8" data-position="3"><span class="menu__link nolink">Our Government</span><ul class="menu"><li class="menu__item is-leaf first leaf menu-mlid-93196 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="1"><a href="/1600/executive-branch" class="menu__link">The Executive Branch</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-93201 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="2"><a href="/1600/legislative-branch" class="menu__link">The Legislative Branch</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-93206 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="3"><a href="/1600/judicial-branch" class="menu__link">The Judicial Branch</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-93211 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="4"><a href="/1600/constitution" class="menu__link">The Constitution</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-93216 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="5"><a href="/1600/federal-agencies-and-commissions" class="menu__link">Federal Agencies &amp; Commissions</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-93231 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="6"><a href="/1600/elections-and-voting" class="menu__link">Elections &amp; Voting</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-93226 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 odd depth-3 no-children" data-position="7"><a href="/1600/state-and-local-government" class="menu__link">State &amp; Local Government</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-93221 horizontal-3-level-menu--menu-item sitewide-footer--main-nav--horizontal-3-level-menu--menu-item sitewide-footer--main-nav--menu-level-3 even depth-3 no-children" data-position="8"><a href="/1600/resources" class="menu__link">Resources</a></li>
+</ul></li>
+</ul></li>
+</ul></div>
+  </nav>
+
+  <nav class="sitewide-footer--utility-nav">
+    <div class="menu-block-wrapper menu-block-ctools-sixteenhundred-nav-utility-1 menu-name-sixteenhundred-nav-utility parent-mlid-0 menu-level-1">
+  <ul class="menu"><li class="menu__item is-leaf first leaf menu-mlid-6451 horizontal-1-level-menu--menu-item sitewide-footer--utility-nav--horizontal-1-level-menu--menu-item odd depth-1 no-children" data-position="1"><a href="http://www.whitehouse.gov/espanol" title="Switch language to Spanish." class="menu__link">En Español</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6456 horizontal-1-level-menu--menu-item sitewide-footer--utility-nav--horizontal-1-level-menu--menu-item even depth-1 no-children" data-position="2"><a href="http://www.whitehouse.gov/accessibility" title="Information about accessibility." class="menu__link">Accessibility</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6461 horizontal-1-level-menu--menu-item sitewide-footer--utility-nav--horizontal-1-level-menu--menu-item odd depth-1 no-children" data-position="3"><a href="http://www.whitehouse.gov/copyright" title="Details about our copyright information." class="menu__link">Copyright Information</a></li>
+<li class="menu__item is-leaf leaf menu-mlid-6466 horizontal-1-level-menu--menu-item sitewide-footer--utility-nav--horizontal-1-level-menu--menu-item even depth-1 no-children" data-position="4"><a href="http://www.whitehouse.gov/privacy" title="Our private policy." class="menu__link">Privacy Policy</a></li>
+<li class="menu__item is-leaf last leaf menu-mlid-6471 horizontal-1-level-menu--menu-item sitewide-footer--utility-nav--horizontal-1-level-menu--menu-item odd depth-1 no-children" data-position="5"><a href="http://www.usa.gov" title="More information about the government." class="menu__link">USA.gov</a></li>
+</ul></div>
+  </nav>
+    </div>
+  </footer>
+  </footer>
+</div>
+</div></section>
+<!-- /Main page content -->
+  <script src="https://www.whitehouse.gov/sites/whitehouse.gov/files/js/js_2mdTQtvwCainuVKOqQsH1BuSMQvOxSgWO1is-qhBFoU.js"></script>
+<script defer="defer" src="//platform.twitter.com/widgets.js" async="TRUE"></script>
+
+
+<div id="fb-root" class=" fb_reset"><div style="position: absolute; top: -10000px; height: 0px; width: 0px;"><div><iframe name="fb_xdm_frame_https" frameborder="0" allowtransparency="true" allowfullscreen="true" scrolling="no" id="fb_xdm_frame_https" aria-hidden="true" title="Facebook Cross Domain Communication Frame" tabindex="-1" src="https://staticxx.facebook.com/connect/xd_arbiter.php?version=42#channel=fecb5ec1b1a9c&amp;origin=https%3A%2F%2Fwww.whitehouse.gov" style="border: none;"></iframe></div></div><div style="position: absolute; top: -10000px; height: 0px; width: 0px;"><div></div></div></div><div id="cboxOverlay" style="display: none;"></div><div id="colorbox" class="" role="dialog" tabindex="-1" style="display: none;"><div id="cboxWrapper"><div><div id="cboxTopLeft" style="float: left;"></div><div id="cboxTopCenter" style="float: left;"></div><div id="cboxTopRight" style="float: left;"></div></div><div style="clear: left;"><div id="cboxMiddleLeft" style="float: left;"></div><div id="cboxContent" style="float: left;"><div id="cboxTitle" style="float: left;"></div><div id="cboxCurrent" style="float: left;"></div><button type="button" id="cboxPrevious"></button><button type="button" id="cboxNext"></button><button id="cboxSlideshow"></button><div id="cboxLoadingOverlay" style="float: left;"></div><div id="cboxLoadingGraphic" style="float: left;"></div></div><div id="cboxMiddleRight" style="float: left;"></div></div><div style="clear: left;"><div id="cboxBottomLeft" style="float: left;"></div><div id="cboxBottomCenter" style="float: left;"></div><div id="cboxBottomRight" style="float: left;"></div></div></div><div style="position: absolute; width: 9999px; visibility: hidden; display: none; max-width: none;"></div></div><iframe id="rufous-sandbox" scrolling="no" frameborder="0" allowtransparency="true" allowfullscreen="true" style="position: absolute; visibility: hidden; display: none; width: 0px; height: 0px; padding: 0px; border: none;"></iframe></body></html>


### PR DESCRIPTION
I noticed that extraction of blogspot articles was really poor. 

Looking at the HTML for blogspot I noticed that these classes are used but they aren't given a high weight by `readability`.

Adding these regexes fixed it for me.

Let me know if you have any concerns. Blogspot is pretty prevalent and it would be great to see readability handle these pages well.

Example page: http://mechanical-sympathy.blogspot.ca/2012/08/memory-access-patterns-are-important.html

Also fixed a failing test. Seems that requesting the white-house website can yield inconsistent results. Downloaded the html and added it as a fixture.