### PR TITLE
Remove all script blocks

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -64,6 +64,12 @@ var prepDocument = module.exports.prepDocument = function(document) {
       }
     }
   }
+  
+  // Strip out all <script> tags, as they *should* be useless
+  var scripts = document.getElementsByTagName('script');
+  [].forEach.call(scripts, function (node) {
+    node.parentNode.removeChild(node);
+  });
 
   // turn all double br's into p's
   // note, this is pretty costly as far as processing goes. Maybe optimize later.


### PR DESCRIPTION
It seems like all `<script>` tags should be removed as part of the document preparation. Typically, script blocks aren't going to contain useful information without running content within them. Additionally, this lib gets hung up on various sites that pack a lot of metadata into inline scripts (which may contain many commas, and thus get an inappropriately high content score).