### PR TITLE
Change redirects count to 3

### DIFF
--- a/src/readability.js
+++ b/src/readability.js
@@ -1,5 +1,5 @@
 var jsdom = require('jsdom');
-var request = require('request');
+var request = require('request').defaults({maxRedirects:3});
 var helpers = require('./helpers');
 var encodinglib = require("encoding");
 var urllib = require('url');


### PR DESCRIPTION
The default for the maximum number of redirects for request is 1. I'm going to make the argument that 1 is simply too low of a count and propose increasing the count to 3. Doing this will allow readability to be a bit more stable since request will not throw errors once redirect count reaches to 2.
