### PR TITLE
Make CLI great again

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env iojs
+#!/usr/bin/env node
 var read = require("./readability.js");
 var argv = require("minimist")(process.argv.slice(2));
 


### PR DESCRIPTION
after iojs has been merged into node, we should change the enviroment to reflect `node` instead of `iojs`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luin/readability/87)
<!-- Reviewable:end -->
