### PR TITLE
Upgrade jsdom version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - 2
-  - 3
   - 4
+  - 6
+  - 8

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "encoding": "~0.1.7",
-    "jsdom": "^6.3.0",
+    "jsdom": "^9.12.0",
     "minimist": "^1.2.0",
     "request": "~2.40.0"
   },


### PR DESCRIPTION
updated to the latest version that supports Node 4, which is 9.12.0

and updated node versions in travis config

@haroldtreen 