### PR TITLE
Bump request package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "encoding": "~0.1.7",
     "jsdom": "^9.12.0",
     "minimist": "^1.2.0",
-    "request": "~2.40.0"
+    "request": "^2.81.0"
   },
   "engines": {
     "node": ">= 2"


### PR DESCRIPTION
Hi! The pinned version of request (2.40) is really ancient and has some issues. Personally, I ran into stack overflows, not to mention all the security issues.

Tests are passing and I think this one is safe to merge.

We should probably go over other dependencies as well, but I guess updating stuff like jsdom is more tricky :)