### PR TITLE
missing the closing braces for options object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,12 @@ read(url, {
 options.preprocess = callback(source, response, contentType, callback);
 ```javascript
 read(url, {
-  preprocess: function(source, response, contentType, callback) {
-    if (source.length > maxBodySize) {
-      return callback(new Error('too big'));
+    preprocess: function(source, response, contentType, callback) {
+      if (source.length > maxBodySize) {
+        return callback(new Error('too big'));
+      }
+      callback(null, source);
     }
-    callback(null, source);
   }, function(err, article, response) {
     //...
   });


### PR DESCRIPTION
Error in the READ.md document.
For preprocess, there needs to be a closing brace for options object.
